### PR TITLE
molecule: cleanup prepare playbooks

### DIFF
--- a/molecule/auditd/prepare.yml
+++ b/molecule/auditd/prepare.yml
@@ -5,29 +5,7 @@
   roles: []
 
   tasks:
-
-    # NOTE: An upgrade of the packages and a reboot is necessary to get
-    #       the latest kernel running.
-
-    - name: Upgrade packages
+    - name: Update package cache
       apt:
-        upgrade: dist
         update_cache: true
       become: true
-
-    - name: Check if /var/run/reboot-required exist
-      stat:
-        path: /var/run/reboot-required
-      register: result
-
-    - name: Reboot system
-      shell: sleep 2 && /sbin/shutdown -r now
-      async: 1
-      poll: 0
-      become: true
-      when: result.stat.islnk is defined
-
-    - name: Wait until remote system is reachable
-      wait_for_connection:
-        delay: 30
-      when: result.stat.islnk is defined

--- a/molecule/osquery/prepare.yml
+++ b/molecule/osquery/prepare.yml
@@ -5,29 +5,7 @@
   roles: []
 
   tasks:
-
-    # NOTE: An upgrade of the packages and a reboot is necessary to get
-    #       the latest kernel running.
-
-    - name: Upgrade packages
+    - name: Update package cache
       apt:
-        upgrade: dist
         update_cache: true
       become: true
-
-    - name: Check if /var/run/reboot-required exist
-      stat:
-        path: /var/run/reboot-required
-      register: result
-
-    - name: Reboot system
-      shell: sleep 2 && /sbin/shutdown -r now
-      async: 1
-      poll: 0
-      become: true
-      when: result.stat.islnk is defined
-
-    - name: Wait until remote system is reachable
-      wait_for_connection:
-        delay: 30
-      when: result.stat.islnk is defined

--- a/molecule/rsyslog/prepare.yml
+++ b/molecule/rsyslog/prepare.yml
@@ -5,29 +5,7 @@
   roles: []
 
   tasks:
-
-    # NOTE: An upgrade of the packages and a reboot is necessary to get
-    #       the latest kernel running.
-
-    - name: Upgrade packages
+    - name: Update package cache
       apt:
-        upgrade: dist
         update_cache: true
       become: true
-
-    - name: Check if /var/run/reboot-required exist
-      stat:
-        path: /var/run/reboot-required
-      register: result
-
-    - name: Reboot system
-      shell: sleep 2 && /sbin/shutdown -r now
-      async: 1
-      poll: 0
-      become: true
-      when: result.stat.islnk is defined
-
-    - name: Wait until remote system is reachable
-      wait_for_connection:
-        delay: 30
-      when: result.stat.islnk is defined


### PR DESCRIPTION
Upgrade + reboot only necessary if an ansible role builds
a kernel module via DKMS.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>