### PR TITLE
auditd: fix default permissions

### DIFF
--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -15,6 +15,7 @@
   template:
     src: auditd.conf.j2
     dest: /etc/audit/audit.conf
+    mode: 0600
   notify: Restart auditd service
   become: true
 


### PR DESCRIPTION
[WARNING]: File '/etc/audit/audit.conf' created with default
permissions '600'. The previous default was '666'.
Specify 'mode' to avoid this warning.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>