### PR TITLE
zabbix_start: start/enable the service after the config tasks

### DIFF
--- a/roles/zabbix_agent/tasks/install-Debian.yml
+++ b/roles/zabbix_agent/tasks/install-Debian.yml
@@ -35,10 +35,3 @@
   apt:
     name: "{{ zabbix_agent_package_name }}"
     state: present
-
-- name: "Start {{ zabbix_agent_service_name }} service"
-  become: true
-  service:
-    name: "{{ zabbix_agent_service_name }}"
-    state: started
-    enabled: true

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -8,6 +8,13 @@
 - name: Include config tasks
   include_tasks: config.yml
 
+- name: "Start {{ zabbix_agent_service_name }} service"
+  become: true
+  service:
+    name: "{{ zabbix_agent_service_name }}"
+    state: started
+    enabled: true
+
 - name: Manage agent extensions
   include_tasks: agent-extension.yml
   loop: "{{ zabbix_agent_extensions }}"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>