### PR TITLE
zabbix_agent: remove old zabbix_agentd.conf.d directory

### DIFF
--- a/roles/zabbix_agent/tasks/cleanup-Debian.yml
+++ b/roles/zabbix_agent/tasks/cleanup-Debian.yml
@@ -24,3 +24,9 @@
   file:
     path: /etc/zabbix/zabbix_agentd.conf
     state: absent
+
+- name: Remove old zabbix_agentd.conf.d directory
+  become: true
+  file:
+    path: /etc/zabbix/zabbix_agentd.conf.d
+    state: absent


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>