### PR TITLE
zabbix_agent: on zabbix server nodes allow the zabbix server network

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+zabbix_network: 172.31.100.112/28
+
 zabbix_agent_server: 127.0.0.1
 
 zabbix_agent_host: "{{ internal_address|default(ansible_default_ipv4.address) }}"

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -6,7 +6,11 @@ LogFile=/var/log/zabbix/zabbix_agent2.log
 LogFileSize=512
 
 SourceIP={{ zabbix_agent_source }}
+{% if 'zabbix' in group_names %}
+Server={{ zabbix_agent_server }},{{ zabbix_network }}
+{% else %}
 Server={{ zabbix_agent_server }}
+{% endif %}
 
 ListenPort={{ zabbix_agent_port }}
 ListenIP={{ zabbix_agent_host }}


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>