### PR TITLE
zabbix_agent: add missing service to handler name

### DIFF
--- a/roles/zabbix_agent/tasks/install-Debian.yml
+++ b/roles/zabbix_agent/tasks/install-Debian.yml
@@ -53,4 +53,4 @@
   apt:
     name: "{{ zabbix_agent_package_name }}"
     state: latest
-  notify: "Restart {{ zabbix_agent_service_name }}"
+  notify: "Restart {{ zabbix_agent_service_name }} service"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>