### PR TITLE
docker: use version 20.10.6

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -73,7 +73,7 @@ docker_pip_extra_args: ""
 
 # NOTE: This "5:" must be prepended starting with version 18.09.
 #       Check available version under Ubuntu with apt-cache madison docker-ce.
-docker_version: "5:20.10.5"
+docker_version: "5:20.10.6"
 
 ##########################
 # registry


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>