### PR TITLE
manager: ansible services depend on inventory_reconciler service

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -34,6 +34,7 @@ services:
       - NETBOX_TOKEN
 {% endif %}
     depends_on:
+      - inventory_reconciler
 {% if redis_enable|bool %}
       - redis
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>