### PR TITLE
jenkins: add missing jenkins_configuration_directory parameter

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -14,6 +14,7 @@ operator_group: "{{ operator_user }}"
 ##########################
 # jenkins
 
+jenkins_configuration_directory: /opt/jenkins/configuration
 jenkins_docker_compose_directory: /opt/jenkins
 
 jenkins_tag: 2


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>