### PR TITLE
jenkins: fix wrong docker registry

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -2,8 +2,7 @@
 ##########################
 # docker
 
-docker_registry: quay.io
-docker_registry_jenkins: "{{ docker_registry }}"
+docker_registry_jenkins: quay.io
 
 ##########################
 # operator user


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>