### PR TITLE
manager: use eventclass sync as default for ara

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -143,7 +143,7 @@ ara_server_host: "{{ ansible_default_ipv4.address }}"
 ara_server_port: 8120
 
 ara_workers: "{{ ansible_processor_vcpus * 2 }}"
-ara_worker_class: eventlet
+ara_worker_class: sync
 
 ara_server_tag: 1.5.4
 ara_server_image: "{{ docker_registry_ara_server }}/osism/ara-server:{{ ara_server_tag }}"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>