### PR TITLE
manager: make mariadb.env file optional

### DIFF
--- a/roles/manager/tasks/config-ara.yml
+++ b/roles/manager/tasks/config-ara.yml
@@ -17,3 +17,4 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  when: ara_server_database_type == "mysql"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>