### PR TITLE
openldap: Use an empty list by default for SERVICE_PROVIDERS (#273)

### DIFF
--- a/roles/openldap/templates/env/openldap.env.j2
+++ b/roles/openldap/templates/env/openldap.env.j2
@@ -8,4 +8,4 @@ CA_CERT_FILE=/run/secrets/ca_cert
 CERT_PEM_FILE=/run/secrets/cert_pem
 
 # A comma separated list of trusted SAML2 Service Provider URLs:
-SERVICE_PROVIDERS=https://ucs-1788.univention-organization.intranet/univention/saml/metadata
+SERVICE_PROVIDERS=''


### PR DESCRIPTION
Signed-off-by: Ferenc Géczi <geczi@univention.de>