### PR TITLE
changed osism.de to osism.tech

### DIFF
--- a/.github/templates/galaxy.yml.j2
+++ b/.github/templates/galaxy.yml.j2
@@ -4,13 +4,13 @@ name: services
 version: {{ tag | regex_replace('^v', '') }}
 readme: README.md
 authors:
-  - OSISM community <info@osism.de> (https://github.com/osism/ansible-collection-services/graphs/contributors)
+  - OSISM community <info@osism.tech> (https://github.com/osism/ansible-collection-services/graphs/contributors)
 description: OSISM service roles
 license_file: LICENSE
 tags:
   - system
 dependencies: {}
 repository: https://github.com/osism/ansible-collection-services.git
-documentation: https://docs.osism.de
-homepage: https://osism.de
+documentation: https://docs.osism.tech
+homepage: https://osism.tech
 issues: https://github.com/osism/ansible-collection-services/issues


### PR DESCRIPTION
Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
