### PR TITLE
Set permissions for default netbox user

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -50,6 +50,7 @@ netbox_initializers:
   - sites
   - tags
   - users
+  - object_permissions
 
 ##########################
 # postgres

--- a/roles/netbox/templates/initializers/object_permissions.yml.j2
+++ b/roles/netbox/templates/initializers/object_permissions.yml.j2
@@ -1,0 +1,11 @@
+read_write_all:
+  enabled: true
+  description: 'Read/Write for All Objects'
+  object_types: all
+  actions:
+    - add
+    - change
+    - delete
+    - view
+  users:
+    - {{ netbox_user_name }}

--- a/roles/netbox/templates/initializers/users.yml.j2
+++ b/roles/netbox/templates/initializers/users.yml.j2
@@ -1,26 +1,3 @@
 ---
 {{ netbox_user_name }}:
   api_token: "{{ netbox_user_api_token }}"
-  # $ ./manage.py shell
-  # > from django.contrib.auth.models import Permission
-  # > print('\n'.join([p.codename for p in Permission.objects.all()]))
-  permissions:
-    - add_device
-    - add_interface
-    - add_ipaddress
-    - change_device
-    - view_cluster
-    - view_device
-    - view_devicerole
-    - view_devicetype
-    - view_interface
-    - view_ipaddress
-    - view_manufacturer
-    - view_platform
-    - view_rack
-    - view_region
-    - view_service
-    - view_site
-    - view_tag
-    - view_tenant
-    - view_virtualmachine


### PR DESCRIPTION
The way of setting permissions has changed. An extra
object_permissions.yml file is created, that links to the user.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>