### PR TITLE
Netbox: use group for setting object permissions

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -50,6 +50,7 @@ netbox_initializers:
   - sites
   - tags
   - users
+  - groups
   - object_permissions
 
 ##########################

--- a/roles/netbox/templates/initializers/groups.yml.j2
+++ b/roles/netbox/templates/initializers/groups.yml.j2
@@ -1,0 +1,4 @@
+---
+writers:
+  users:
+    - "{{ netbox_user_name }}"

--- a/roles/netbox/templates/initializers/object_permissions.yml.j2
+++ b/roles/netbox/templates/initializers/object_permissions.yml.j2
@@ -7,5 +7,5 @@ read_write_all:
     - change
     - delete
     - view
-  users:
-    - {{ netbox_user_name }}
+  groups:
+    - writers


### PR DESCRIPTION
There is a bug in the initializer scripts, which prevents proper
permission initialization for users. Set object permissions via group.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>