### PR TITLE
Run patchman_postgres on tmpfs volume

### DIFF
--- a/roles/patchman/templates/docker-compose.yml.j2
+++ b/roles/patchman/templates/docker-compose.yml.j2
@@ -35,6 +35,9 @@ services:
 
 volumes:
   postgres:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
 
 networks:
  default:


### PR DESCRIPTION
The initial repository import is very IO intensive and may exceed the
timeout of 30 minutes in the testbed deployment. Since the data can be
considered ephemeral, we switch to using a tmpfs volume, which reduces
the runtime to about 10 minutes.

Closes: #352
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>