### PR TITLE
manager: reduce number of ara-workers to 5

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -143,7 +143,7 @@ ara_password: password
 ara_server_host: "{{ ansible_default_ipv4.address }}"
 ara_server_port: 8120
 
-ara_workers: "{{ ansible_processor_vcpus * 2 }}"
+ara_workers: 5
 ara_worker_class: sync
 
 ara_server_tag: 1.5.4


### PR DESCRIPTION
On manager nodes with many threads, the current default leads
to a very high number of processes.

Signed-off-by: Christian Berendt <berendt@osism.tech>