### PR TITLE
Read Traefik TLS keys and certificates from variables

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -29,7 +29,12 @@ traefik_port: 8122
 traefik_port_http: 80
 traefik_port_https: 443
 
-traefik_certificates: []
+# traefik_tls_certs:
+#   dashboard: "-----BEGIN CERTIFICATE-----..."
+traefik_tls_certs: {}
+# traefik_tls_keys:
+#   dashboard: "-----BEGIN PRIVATE KEY-----..."
+traefik_tls_keys: {}
 
 traefik_tag: v2.5.4
 traefik_image: "{{ docker_registry_traefik }}/traefik:{{ traefik_tag }}"

--- a/roles/traefik/tasks/config.yml
+++ b/roles/traefik/tasks/config.yml
@@ -25,18 +25,18 @@
 
 - name: Copy certificate cert files
   copy:
-    src: "{{ configuration_directory }}/environments/manager/certificates/{{ item }}.cert"
-    dest: "{{ traefik_certificates_directory }}/{{ item }}.cert"
+    content: "{{ item.value }}"
+    dest: "{{ traefik_certificates_directory }}/{{ item.key }}.cert"
     mode: 0644
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
-  loop: "{{ traefik_certificates }}"
+  loop: "{{ traefik_tls_certs | dict2items }}"
 
 - name: Copy certificate key files
   copy:
-    src: "{{ configuration_directory }}/environments/manager/certificates/{{ item }}.key"
-    dest: "{{ traefik_certificates_directory }}/{{ item }}.key"
+    content: "{{ item.value }}"
+    dest: "{{ traefik_certificates_directory }}/{{ item.key }}.key"
     mode: 0644
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
-  loop: "{{ traefik_certificates }}"
+  loop: "{{ traefik_tls_keys | dict2items }}"

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -15,11 +15,11 @@ entryPoints:
   https:
     address: ":443"
 
-{% if traefik_certificates|length >0 %}
+{% if traefik_tls_certs.keys() | length >0 %}
 tls:
   certificates:
-{% for certificate in traefik_certificates %}
-    - certFile: /etc/traefik/certificates/{{ certificate }}.cert
-      keyFile: /etc/traefik/certificates/{{ certificate }}.key
+{% for certificate_name in traefik_tls_certs.keys() %}
+    - certFile: /etc/traefik/certificates/{{ certificate_name }}.cert
+      keyFile: /etc/traefik/certificates/{{ certificate_name }}.key
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
To ensure the TLS keys can be encrypted in ansible-vault the keys and
certificates are fetched from variables.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>