### PR TITLE
traefik: consolidate TLS cert and key dictionary

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -29,12 +29,11 @@ traefik_port: 8122
 traefik_port_http: 80
 traefik_port_https: 443
 
-# traefik_tls_certs:
-#   dashboard: "-----BEGIN CERTIFICATE-----..."
-traefik_tls_certs: {}
-# traefik_tls_keys:
-#   dashboard: "-----BEGIN PRIVATE KEY-----..."
-traefik_tls_keys: {}
+# traefik_certificates:
+#   dashboard:
+#     cert: "-----BEGIN CERTIFICATE-----..."
+#     key: "-----BEGIN PRIVATE KEY-----..."
+traefik_certificates: {}
 
 traefik_tag: v2.5.4
 traefik_image: "{{ docker_registry_traefik }}/traefik:{{ traefik_tag }}"

--- a/roles/traefik/tasks/config.yml
+++ b/roles/traefik/tasks/config.yml
@@ -25,18 +25,18 @@
 
 - name: Copy certificate cert files
   copy:
-    content: "{{ item.value }}"
+    content: "{{ item.value.cert }}"
     dest: "{{ traefik_certificates_directory }}/{{ item.key }}.cert"
     mode: 0644
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
-  loop: "{{ traefik_tls_certs | dict2items }}"
+  loop: "{{ traefik_certificates | dict2items }}"
 
 - name: Copy certificate key files
   copy:
-    content: "{{ item.value }}"
+    content: "{{ item.value.key }}"
     dest: "{{ traefik_certificates_directory }}/{{ item.key }}.key"
     mode: 0644
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
-  loop: "{{ traefik_tls_keys | dict2items }}"
+  loop: "{{ traefik_certificates | dict2items }}"

--- a/roles/traefik/templates/docker-compose.yml.j2
+++ b/roles/traefik/templates/docker-compose.yml.j2
@@ -17,7 +17,7 @@ services:
       - "{{ traefik_configuration_directory }}/osism.yml:/etc/traefik/osism.yml:ro"
       - "{{ traefik_configuration_directory }}/traefik.yml:/etc/traefik/traefik.yml:ro"
       - /var/run/docker.sock:/var/run/docker.sock
-{% if traefik_certificates|length > 0 %}
+{% if traefik_certificates.keys() | length >0 %}
       - "{{ traefik_certificates_directory }}:/etc/traefik/certificates:ro"
 {% endif %}
     networks:

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -15,11 +15,11 @@ entryPoints:
   https:
     address: ":443"
 
-{% if traefik_tls_certs.keys() | length >0 %}
+{% if traefik_certificates.keys() | length >0 %}
 tls:
   certificates:
-{% for certificate_name in traefik_tls_certs.keys() %}
-    - certFile: /etc/traefik/certificates/{{ certificate_name }}.cert
-      keyFile: /etc/traefik/certificates/{{ certificate_name }}.key
+{% for certificate in traefik_certificates.keys() %}
+    - certFile: /etc/traefik/certificates/{{ certificate }}.cert
+      keyFile: /etc/traefik/certificates/{{ certificate }}.key
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
- Use one dictionary for TLS certificates and key as subelements
- Fix statement in docker-compose.yml