### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,12 +1,11 @@
 ---
 - name: Converge
   hosts: all
-
   tasks:
     - name: Include required variables
-      include_vars:
+      ansible.builtin.include_vars:
         file: "vars/{{ molecule_role }}.yml"
 
     - name: "Include {{ molecule_role }} role"
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ molecule_role }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,8 +1,7 @@
 ---
 - name: Prepare
   hosts: all
-
   tasks:
     - name: Include required prepare tasks
-      include_tasks:
+      ansible.builtin.include_tasks:
         file: "prepare/{{ molecule_role }}.yml"

--- a/molecule/default/prepare/chrony.yml
+++ b/molecule/default/prepare/chrony.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/default/prepare/hddtemp.yml
+++ b/molecule/default/prepare/hddtemp.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/default/prepare/rng.yml
+++ b/molecule/default/prepare/rng.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,8 +1,7 @@
 ---
 - name: Verify
   hosts: all
-
   tasks:
     - name: Include required verify tasks
-      include_tasks:
+      ansible.builtin.include_tasks:
         file: "verify/{{ molecule_role }}.yml"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/default Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
