### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/molecule/delegated/converge.yml
+++ b/molecule/delegated/converge.yml
@@ -1,12 +1,11 @@
 ---
 - name: Converge
   hosts: all
-
   tasks:
     - name: Include required variables
-      include_vars:
+      ansible.builtin.include_vars:
         file: "vars/{{ molecule_role }}.yml"
 
     - name: "Include {{ molecule_role }} role"
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ molecule_role }}"

--- a/molecule/delegated/prepare.yml
+++ b/molecule/delegated/prepare.yml
@@ -1,8 +1,7 @@
 ---
 - name: Prepare
   hosts: all
-
   tasks:
     - name: Include required prepare tasks
-      include_tasks:
+      ansible.builtin.include_tasks:
         file: "prepare/{{ molecule_role }}.yml"

--- a/molecule/delegated/prepare/auditd.yml
+++ b/molecule/delegated/prepare/auditd.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/cockpit.yml
+++ b/molecule/delegated/prepare/cockpit.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/fail2ban.yml
+++ b/molecule/delegated/prepare/fail2ban.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/netdata.yml
+++ b/molecule/delegated/prepare/netdata.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/rsyslog.yml
+++ b/molecule/delegated/prepare/rsyslog.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/smartd.yml
+++ b/molecule/delegated/prepare/smartd.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/prepare/tailscale.yml
+++ b/molecule/delegated/prepare/tailscale.yml
@@ -1,5 +1,5 @@
 ---
 - name: Update package cache
   become: true
-  apt:
+  ansible.builtin.apt:
     update_cache: true

--- a/molecule/delegated/verify.yml
+++ b/molecule/delegated/verify.yml
@@ -1,8 +1,7 @@
 ---
 - name: Verify
   hosts: all
-
   tasks:
     - name: Include required verify tasks
-      include_tasks:
+      ansible.builtin.include_tasks:
         file: "verify/{{ molecule_role }}.yml"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/molecule/delegated Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
