### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/adminer/handlers/main.yml
+++ b/roles/adminer/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart adminer service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ adminer_service_name }}"
     state: restarted

--- a/roles/adminer/tasks/main.yml
+++ b/roles/adminer/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create required directories
   become: true
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ operator_user }}"
@@ -11,7 +11,7 @@
     - "{{ adminer_docker_compose_directory }}"
 
 - name: Copy docker-compose.yml file
-  template:
+  ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ adminer_docker_compose_directory }}/docker-compose.yml"
     owner: "{{ operator_user }}"
@@ -21,7 +21,7 @@
 
 - name: Start/enable adminer service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ adminer_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/adminer Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
