### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/auditd/handlers/main.yml
+++ b/roles/auditd/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Restart auditd service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ auditd_service_name }}"
     state: restarted
 
 - name: Generate auditd rules
   become: true
-  command: augenrules --load
+  ansible.builtin.command: augenrules --load
   notify: Restart auditd service

--- a/roles/auditd/tasks/install-Debian.yml
+++ b/roles/auditd/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,12 +8,12 @@
 
 - name: Install auditd package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ auditd_package_name }}"
     state: present
 
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -21,6 +21,6 @@
 
 - name: Install audispd-plugins package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ audispd_plugins_package_name }}"
     state: present

--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Copy auditd.conf configuration files
   become: true
-  template:
+  ansible.builtin.template:
     src: auditd.conf.j2
     dest: /etc/audit/audit.conf
     mode: 0640
@@ -12,7 +12,7 @@
 
 - name: Adjust auditd/audispd configurations
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "{{ item.config }}"
     regexp: '^#?{{ item.parameter }}\s*='
     line: "{{ item.parameter }} = {{ item.value }}"
@@ -22,7 +22,7 @@
 
 - name: Deploy rules for auditd
   become: true
-  template:
+  ansible.builtin.template:
     src: "rules/{{ item }}.j2"
     dest: "{{ auditd_rules_path }}/{{ item }}"
     owner: root
@@ -34,20 +34,20 @@
 
 - name: Start/enable auditd service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ auditd_service_name }}"
     state: started
     enabled: true
 
 - name: List existing rules files
   become: true
-  command: "find {{ auditd_rules_path }} -type f -printf '%f\n'"
+  ansible.builtin.command: "find {{ auditd_rules_path }} -type f -printf '%f\n'"
   changed_when: false
   register: auditd_existing_rules
 
 - name: Remove unmanaged rules files
   become: true
-  file:
+  ansible.builtin.file:
     dest: "{{ auditd_rules_path }}/{{ item }}"
     state: absent
   when:


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/auditd Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
