### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/chrony/handlers/main.yml
+++ b/roles/chrony/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart chrony service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ chrony_service_name }}"
     state: restarted

--- a/roles/chrony/tasks/install-Debian.yml
+++ b/roles/chrony/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ chrony_package_name }}"
     state: present

--- a/roles/chrony/tasks/install-RedHat.yml
+++ b/roles/chrony/tasks/install-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install package
   become: true
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ chrony_package_name }}"
     state: present

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
 - name: Gather variables for each operating system
-  include_vars: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Stop/disable timesyncd service
   become: true
-  service:
+  ansible.builtin.service:
     name: systemd-timesyncd
     state: stopped
     enabled: false
   when: ansible_os_family == "Debian"
 
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Start/enable chrony
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ chrony_service_name }}"
     state: started
     enabled: true
 
 - name: Check if configuration file exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ chrony_conf_file }}"
   register: chrony_conf_check
 
 - name: Copy configuration file
   become: true
-  template:
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ chrony_conf_file }}"
     mode: 0644


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/chrony Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
