### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/fail2ban/tasks/install-Debian.yml
+++ b/roles/fail2ban/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install fail2ban package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ fail2ban_package_name }}"
     state: present

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Start/enable fail2ban service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ fail2ban_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/fail2ban Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
