### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/frr/handlers/main.yml
+++ b/roles/frr/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart frr service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ frr_service_name }}"
     state: restarted

--- a/roles/frr/tasks/install-Debian.yml
+++ b/roles/frr/tasks/install-Debian.yml
@@ -1,13 +1,13 @@
 ---
 - name: Wait for apt lock
   become: true
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
 
 - name: Install frr package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ frr_package_name }}"
     state: present

--- a/roles/frr/tasks/main.yml
+++ b/roles/frr/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Set sysctl parameters
   become: true
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     state: present
@@ -14,7 +14,7 @@
 
 - name: Start/enable frr service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ frr_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/frr Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
