### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/minikube/tasks/main.yml
+++ b/roles/minikube/tasks/main.yml
@@ -6,14 +6,14 @@
   register: tmpfile
 
 - name: Download minikube package
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ minikube_package_url }}"
     dest: "{{ tmpfile.path }}"
     force: true
 
 - name: Install minikube package
   become: true
-  apt:
+  ansible.builtin.apt:
     deb: "{{ tmpfile.path }}"
 
 - name: Remove temporary file
@@ -24,7 +24,7 @@
 
 - name: Copy minikube systemd unit file
   become: true
-  template:
+  ansible.builtin.template:
     src: minikube.service.j2
     dest: "/etc/systemd/system/{{ minikube_service_name }}.service"
     mode: 0644
@@ -34,13 +34,13 @@
 
 - name: Reload systemd daemon if minikube systemd unit file is changed
   become: true
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
   when: systemd_minikube_template is changed
 
 - name: "Start/enable {{ minikube_service_name }} service"
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ minikube_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/minikube Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
