### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/openstack_health_monitor/tasks/container-Debian.yml
+++ b/roles/openstack_health_monitor/tasks/container-Debian.yml
@@ -1,11 +1,11 @@
 ---
 - name: Gather the apt package facts
-  package_facts:
+  ansible.builtin.package_facts:
     manager: auto
 
 - name: Create required directories
   become: true
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ operator_user }}"
@@ -17,7 +17,7 @@
     - "{{ openstack_health_monitor_docker_compose_directory }}"
 
 - name: Copy environment file
-  template:
+  ansible.builtin.template:
     src: env/openstack_health_monitor.env.j2
     dest: "{{ openstack_health_monitor_configuration_directory }}/openstack_health_monitor.env"
     mode: 0640
@@ -25,7 +25,7 @@
     group: "{{ operator_group }}"
 
 - name: Copy clouds.yml file
-  copy:
+  ansible.builtin.copy:
     src: "{{ openstack_health_monitor_clouds_yml_path }}"
     dest: "{{ openstack_health_monitor_configuration_directory }}/clouds.yml"
     mode: 0640
@@ -33,7 +33,7 @@
     group: "{{ operator_group }}"
 
 - name: Copy secure.yml file
-  copy:
+  ansible.builtin.copy:
     src: "{{ openstack_health_monitor_secure_yml_path }}"
     dest: "{{ openstack_health_monitor_configuration_directory }}/secure.yml"
     mode: 0640
@@ -41,7 +41,7 @@
     group: "{{ operator_group }}"
 
 - name: Copy docker-compose.yml file
-  template:
+  ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ openstack_health_monitor_docker_compose_directory }}/docker-compose.yml"
     owner: "{{ operator_user }}"
@@ -49,7 +49,7 @@
     mode: 0640
 
 - name: Run service
-  docker_compose:
+  community.docker.docker_compose:
     project_src: "{{ openstack_health_monitor_docker_compose_directory }}"
     build: false
     pull: true
@@ -60,19 +60,19 @@
 #       Therefore in this case docker-compose is called directly.
 
 - name: Pull images
-  command: "docker-compose -f {{ openstack_health_monitor_docker_compose_directory }}/docker-compose.yml pull"
+  ansible.builtin.command: "docker-compose -f {{ openstack_health_monitor_docker_compose_directory }}/docker-compose.yml pull"
   register: result
   changed_when: ('Downloaded' in result.stdout)
   when: "'docker-compose' not in ansible_facts.packages"
 
 - name: Run service
-  command: "docker-compose -f {{ openstack_health_monitor_docker_compose_directory }}/docker-compose.yml up -d --remove-orphans --no-build"
+  ansible.builtin.command: "docker-compose -f {{ openstack_health_monitor_docker_compose_directory }}/docker-compose.yml up -d --remove-orphans --no-build"
   register: result
   changed_when: ('Creating' in result.stdout or 'Recreating' in result.stdout)
   when: "'docker-compose' not in ansible_facts.packages"
 
 - name: Create cronjob
-  cron:
+  ansible.builtin.cron:
     name: run openstack health monitor script
     minute: "{{ openstack_health_monitor_cronjob_minute }}"
     hour: "{{ openstack_health_monitor_cronjob_hour }}"

--- a/roles/openstack_health_monitor/tasks/main.yml
+++ b/roles/openstack_health_monitor/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Include tasks
-  include: "{{ openstack_health_monitor_install_type }}-{{ ansible_os_family }}.yml"
+  ansible.builtin.include: "{{ openstack_health_monitor_install_type }}-{{ ansible_os_family }}.yml"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/openstack_health_monitor Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
