### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/rng/tasks/install-Debian.yml
+++ b/roles/rng/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install rng package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ rng_package_name }}"
     state: present

--- a/roles/rng/tasks/install-RedHat.yml
+++ b/roles/rng/tasks/install-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install rng package
   become: true
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ rng_package_name }}"
     state: present

--- a/roles/rng/tasks/main.yml
+++ b/roles/rng/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Start/enable rng service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ rng_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/rng
 Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
