### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart rsyslog service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ rsyslog_service_name }}"
     state: restarted

--- a/roles/rsyslog/tasks/fluentd.yml
+++ b/roles/rsyslog/tasks/fluentd.yml
@@ -1,7 +1,7 @@
 ---
 - name: Forward syslog message to local fluentd daemon
   become: true
-  template:
+  ansible.builtin.template:
     src: 70-fluentd.conf.j2
     dest: /etc/rsyslog.d/70-fluentd.conf
     owner: root

--- a/roles/rsyslog/tasks/install-Debian.yml
+++ b/roles/rsyslog/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install rsyslog package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ rsyslog_package_name }}"
     state: present

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include distribution specific install tasks
-  include_tasks: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Copy rsyslog.conf configuration file
   become: true
-  template:
+  ansible.builtin.template:
     src: rsyslog.conf.j2
     dest: /etc/rsyslog.conf
     mode: 0644
@@ -14,12 +14,12 @@
 
 - name: Start/enable rsyslog service
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ rsyslog_service_name }}"
     state: started
     enabled: true
 
 - name: Include fluentd tasks
-  include: fluentd.yml
+  ansible.builtin.include: fluentd.yml
   tags: fluentd
   when: rsyslog_fluentd|bool


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-services/roles/rsyslog Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
