### PR TITLE
Traefik: Add dynamic configuration for TLS certificates

### DIFF
--- a/roles/traefik/tasks/config.yml
+++ b/roles/traefik/tasks/config.yml
@@ -22,6 +22,7 @@
   loop:
     - traefik.yml
     - traefik.env
+    - certificates.yml
 
 - name: Copy certificate cert files
   copy:

--- a/roles/traefik/templates/certificates.yml.j2
+++ b/roles/traefik/templates/certificates.yml.j2
@@ -1,0 +1,9 @@
+---
+{% if traefik_certificates.keys() | length >0 %}
+tls:
+  certificates:
+{% for certificate in traefik_certificates.keys() %}
+    - certFile: /etc/traefik/certificates/{{ certificate }}.cert
+      keyFile: /etc/traefik/certificates/{{ certificate }}.key
+{% endfor %}
+{% endif %}

--- a/roles/traefik/templates/docker-compose.yml.j2
+++ b/roles/traefik/templates/docker-compose.yml.j2
@@ -16,10 +16,11 @@ services:
       - "/etc/hosts:/etc/hosts:ro"
       - "{{ traefik_configuration_directory }}/osism.yml:/etc/traefik/osism.yml:ro"
       - "{{ traefik_configuration_directory }}/traefik.yml:/etc/traefik/traefik.yml:ro"
-      - /var/run/docker.sock:/var/run/docker.sock
+      - "{{ traefik_configuration_directory }}/certificates.yml:/etc/traefik/dynamic/certificates.yml:ro"
 {% if traefik_certificates.keys() | length >0 %}
       - "{{ traefik_certificates_directory }}:/etc/traefik/certificates:ro"
 {% endif %}
+      - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - default
       - {{ traefik_external_network_name }}

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -3,6 +3,8 @@ providers:
   docker:
     endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
+  file:
+    directory: "/etc/traefik/dynamic"
 
 api:
   insecure: true
@@ -14,12 +16,3 @@ entryPoints:
 
   https:
     address: ":443"
-
-{% if traefik_certificates.keys() | length >0 %}
-tls:
-  certificates:
-{% for certificate in traefik_certificates.keys() %}
-    - certFile: /etc/traefik/certificates/{{ certificate }}.cert
-      keyFile: /etc/traefik/certificates/{{ certificate }}.key
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
TLS certificate files have to be configured in a dynamic configuration
file to be usable in conjuction with config options from Docker
provider.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>