### PR TITLE
nexus: do not wait for the service

### DIFF
--- a/roles/nexus/tasks/initialize.yml
+++ b/roles/nexus/tasks/initialize.yml
@@ -1,9 +1,4 @@
 ---
-- name: Wait for nexus service
-  ansible.builtin.wait_for:
-    host: "{{ nexus_host }}"
-    port: "{{ nexus_port }}"
-
 - name: Get admin password
   community.docker.docker_container_exec:
     container: "{{ nexus_container_name }}"


### PR DESCRIPTION
The internal scripts now take over.

Signed-off-by: Christian Berendt <berendt@osism.tech>