### PR TITLE
Set MTU for container networks

### DIFF
--- a/roles/adminer/defaults/main.yml
+++ b/roles/adminer/defaults/main.yml
@@ -23,6 +23,7 @@ adminer_port: 8111
 adminer_tag: 4.7
 adminer_image: "{{ docker_registry_adminer }}/library/adminer:{{ adminer_tag }}"
 
+docker_network_mtu: 1500
 adminer_network: 172.31.100.64/28
 
 adminer_service_name: "docker-compose@adminer"

--- a/roles/adminer/templates/docker-compose.yml.j2
+++ b/roles/adminer/templates/docker-compose.yml.j2
@@ -16,9 +16,11 @@ services:
       test: curl --silent --fail localhost:8080
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ adminer_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ adminer_network }}

--- a/roles/cephclient/defaults/main.yml
+++ b/roles/cephclient/defaults/main.yml
@@ -32,6 +32,7 @@ cephclient_image: "{{ docker_registry_cephclient }}/osism/cephclient:{{ cephclie
 
 cephclient_container_name: cephclient
 
+docker_network_mtu: 1500
 cephclient_network: 172.31.100.0/28
 
 cephclient_service_name: "docker-compose@cephclient"

--- a/roles/cephclient/templates/docker-compose.yml.j2
+++ b/roles/cephclient/templates/docker-compose.yml.j2
@@ -13,9 +13,11 @@ services:
       - "/etc/hosts:/etc/hosts:ro"
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ cephclient_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ cephclient_network }}

--- a/roles/homer/defaults/main.yml
+++ b/roles/homer/defaults/main.yml
@@ -24,6 +24,7 @@ homer_image: "{{ docker_registry_homer }}/osism/homer:{{ homer_tag }}"
 
 homer_container_name: homer
 
+docker_network_mtu: 1500
 homer_network: 172.31.100.208/28
 
 homer_service_name: "docker-compose@homer"

--- a/roles/homer/templates/docker-compose.yml.j2
+++ b/roles/homer/templates/docker-compose.yml.j2
@@ -12,9 +12,11 @@ services:
       - "{{ homer_configuration_directory }}/config.yml:/www/assets/config.yml:ro"
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet: {{ homer_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet: {{ homer_network }}

--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -22,6 +22,7 @@ jenkins_image: "{{ docker_registry_jenkins }}/osism/jenkins:{{ jenkins_tag }}"
 jenkins_host: 127.0.0.1
 jenkins_port: 4441
 
+docker_network_mtu: 1500
 jenkins_network: 172.31.100.224/28
 
 jenkins_password: password

--- a/roles/jenkins/templates/docker-compose.yml.j2
+++ b/roles/jenkins/templates/docker-compose.yml.j2
@@ -18,9 +18,11 @@ volumes:
   jenkins:
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ jenkins_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ jenkins_network }}

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -18,6 +18,7 @@ keycloak_configuration_directory: /opt/keycloak/configuration
 keycloak_secrets_directory: /opt/keycloak/secrets
 keycloak_docker_compose_directory: /opt/keycloak
 
+docker_network_mtu: 1500
 keycloak_network: 172.31.100.144/28
 keycloak_container_name: keycloak
 keycloak_service_name: "docker-compose@keycloak"

--- a/roles/keycloak/templates/docker-compose.yml.j2
+++ b/roles/keycloak/templates/docker-compose.yml.j2
@@ -39,9 +39,11 @@ secrets:
 {% endif %}
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ keycloak_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ keycloak_network }}

--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -17,6 +17,7 @@ docker_registry_receptor: "{{ docker_registry_ansible }}"
 docker_registry_redis: "{{ docker_registry_service }}"
 docker_registry_vault: "{{ docker_registry_service }}"
 
+docker_network_mtu: 1500
 manager_network: 172.31.101.0/28
 
 manager_service_name: "docker-compose@manager"

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -316,9 +316,11 @@ secrets:
 {% endif %}
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ manager_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ manager_network }}

--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -19,6 +19,7 @@ netbox_configuration_directory: /opt/netbox/configuration
 netbox_secrets_directory: /opt/netbox/secrets
 netbox_docker_compose_directory: /opt/netbox
 
+docker_network_mtu: 1500
 netbox_network: 172.31.100.176/28
 netbox_service_name: "docker-compose@netbox"
 

--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -101,13 +101,15 @@ secrets:
     file: {{ netbox_secrets_directory }}/POSTGRES_PASSWORD
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ netbox_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ netbox_network }}
 {% if netbox_traefik|bool %}
- {{ traefik_external_network_name }}:
-   external: true
+  {{ traefik_external_network_name }}:
+    external: true
 {% endif %}

--- a/roles/nexus/defaults/main.yml
+++ b/roles/nexus/defaults/main.yml
@@ -23,6 +23,7 @@ nexus_port: 8190
 nexus_tag: 3.36.0
 nexus_image: "{{ docker_registry_nexus }}/osism/nexus:{{ nexus_tag }}"
 
+docker_network_mtu: 1500
 nexus_network: 172.31.101.32/28
 
 nexus_container_name: nexus

--- a/roles/nexus/templates/docker-compose.yml.j2
+++ b/roles/nexus/templates/docker-compose.yml.j2
@@ -51,13 +51,15 @@ volumes:
   data:
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet: {{ nexus_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet: {{ nexus_network }}
 {% if enable_nexus_traefik|bool %}
- {{ traefik_external_network_name }}:
-   external: true
+  {{ traefik_external_network_name }}:
+    external: true
 {% endif %}

--- a/roles/openldap/defaults/main.yml
+++ b/roles/openldap/defaults/main.yml
@@ -19,6 +19,7 @@ openldap_configuration_directory: /opt/openldap/configuration
 openldap_secrets_directory: /opt/openldap/secrets
 openldap_docker_compose_directory: /opt/openldap
 
+docker_network_mtu: 1500
 openldap_network: 172.31.100.240/28
 openldap_container_name: openldap
 openldap_service_name: "docker-compose@openldap"

--- a/roles/openldap/templates/docker-compose.yml.j2
+++ b/roles/openldap/templates/docker-compose.yml.j2
@@ -109,9 +109,11 @@ secrets:
     file: {{ openldap_secrets_directory }}/private.key
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ openldap_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ openldap_network }}

--- a/roles/openstack_health_monitor/defaults/main.yml
+++ b/roles/openstack_health_monitor/defaults/main.yml
@@ -51,4 +51,5 @@ openstack_health_monitor_image: "{{ docker_registry_openstack_health_monitor }}/
 
 openstack_health_monitor_container_name: openstack_health_monitor
 
+docker_network_mtu: 1500
 openstack_health_monitor_network: 172.31.100.160/28

--- a/roles/openstack_health_monitor/templates/docker-compose.yml.j2
+++ b/roles/openstack_health_monitor/templates/docker-compose.yml.j2
@@ -18,9 +18,11 @@ volumes:
   data:
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ openstack_health_monitor_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ openstack_health_monitor_network }}

--- a/roles/openstackclient/defaults/main.yml
+++ b/roles/openstackclient/defaults/main.yml
@@ -28,6 +28,7 @@ openstackclient_image: "{{ docker_registry_openstackclient }}/osism/openstackcli
 
 openstackclient_container_name: openstackclient
 
+docker_network_mtu: 1500
 openstackclient_network: 172.31.100.16/28
 
 openstackclient_service_name: "docker-compose@openstackclient"

--- a/roles/openstackclient/templates/docker-compose.yml.j2
+++ b/roles/openstackclient/templates/docker-compose.yml.j2
@@ -13,9 +13,11 @@ services:
       - "/etc/hosts:/etc/hosts:ro"
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ openstackclient_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ openstackclient_network }}

--- a/roles/patchman/defaults/main.yml
+++ b/roles/patchman/defaults/main.yml
@@ -26,6 +26,7 @@ patchman_image: "{{ docker_registry_patchman }}/osism/patchman:{{ patchman_tag }
 
 patchman_container_name: patchman
 
+docker_network_mtu: 1500
 patchman_network: 172.31.100.80/28
 
 patchman_service_name: "docker-compose@patchman"

--- a/roles/patchman/templates/docker-compose.yml.j2
+++ b/roles/patchman/templates/docker-compose.yml.j2
@@ -40,9 +40,11 @@ volumes:
       device: tmpfs
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ patchman_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ patchman_network }}

--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -23,6 +23,7 @@ phpmyadmin_port: 8110
 phpmyadmin_tag: 4.9
 phpmyadmin_image: "{{ docker_registry_phpmyadmin }}/phpmyadmin/phpmyadmin:{{ phpmyadmin_tag }}"
 
+docker_network_mtu: 1500
 phpmyadmin_network: 172.31.100.32/28
 
 phpmyadmin_service_name: "docker-compose@phpmyadmin"

--- a/roles/phpmyadmin/templates/docker-compose.yml.j2
+++ b/roles/phpmyadmin/templates/docker-compose.yml.j2
@@ -16,9 +16,11 @@ services:
       test: curl --silent --fail localhost:80
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ phpmyadmin_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ phpmyadmin_network }}

--- a/roles/rundeck/defaults/main.yml
+++ b/roles/rundeck/defaults/main.yml
@@ -18,6 +18,7 @@ rundeck_configuration_directory: /opt/rundeck/configuration
 rundeck_secrets_directory: /opt/rundeck/secrets
 rundeck_docker_compose_directory: /opt/rundeck
 
+docker_network_mtu: 1500
 rundeck_network: 172.31.100.192/28
 rundeck_service_name: "docker-compose@rundeck"
 

--- a/roles/rundeck/templates/docker-compose.yml.j2
+++ b/roles/rundeck/templates/docker-compose.yml.j2
@@ -35,9 +35,11 @@ secrets:
     file: {{ rundeck_secrets_directory }}/POSTGRES_PASSWORD
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ rundeck_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ rundeck_network }}

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -38,6 +38,7 @@ traefik_certificates: {}
 traefik_tag: v2.5.4
 traefik_image: "{{ docker_registry_traefik }}/traefik:{{ traefik_tag }}"
 
+docker_network_mtu: 1500
 traefik_network: 172.31.101.48/28
 
 traefik_container_name: traefik

--- a/roles/traefik/templates/docker-compose.yml.j2
+++ b/roles/traefik/templates/docker-compose.yml.j2
@@ -26,11 +26,13 @@ services:
       - {{ traefik_external_network_name }}
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet: {{ traefik_network }}
- {{ traefik_external_network_name }}:
-   external: true
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet: {{ traefik_network }}
+  {{ traefik_external_network_name }}:
+    external: true

--- a/roles/virtualbmc/defaults/main.yml
+++ b/roles/virtualbmc/defaults/main.yml
@@ -16,6 +16,7 @@ docker_registry_virtualbmc: quay.io
 virtualbmc_configuration_directory: /opt/virtualbmc/configuration
 virtualbmc_docker_compose_directory: /opt/virtualbmc
 
+docker_network_mtu: 1500
 virtualbmc_network: 172.31.101.16/28
 virtualbmc_service_name: "docker-compose@virtualbmc"
 

--- a/roles/virtualbmc/templates/docker-compose.yml.j2
+++ b/roles/virtualbmc/templates/docker-compose.yml.j2
@@ -16,9 +16,11 @@ volumes:
     external: true
 
 networks:
- default:
-   driver: bridge
-   ipam:
-     driver: default
-     config:
-       - subnet:  {{ virtualbmc_network }}
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ virtualbmc_network }}


### PR DESCRIPTION
In order to set the network MTU for containers created by
docker-compose, the corresponding option needs to be set in the
Dockerfile explicitly. Default to 1500 but allow the value to be
overridden e.g. for virtualized deployments.

Partial: osism/testbed#912
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>