### PR TITLE
Netbox: Allow undefined environment variables

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -46,12 +46,16 @@ netbox_ldap_enable: false
 netbox_ldap_server_uri: "ldap://localhost:389"
 netbox_ldap_bind_dn: ""
 netbox_ldap_bind_password: ""
-netbox_ldap_user_dn_template: ""
+netbox_ldap_user_dn_template:
 netbox_ldap_user_search_attr: "sAMAccountName"
 netbox_ldap_user_search_basedn: ""
 netbox_ldap_group_search_class: "group"
 netbox_ldap_group_search_basedn: ""
-netbox_ldap_group_type: "GroupOfNamesType"
+netbox_ldap_group_type: "NestedGroupOfNamesType"
+
+netbox_ldap_require_group_dn:
+netbox_ldap_is_admin_dn:
+netbox_ldap_is_superuser_dn:
 
 netbox_ldap_start_tls: false
 netbox_ldap_ignore_cert_errors: false

--- a/roles/netbox/templates/env/netbox.env.j2
+++ b/roles/netbox/templates/env/netbox.env.j2
@@ -20,22 +20,24 @@ REMOTE_AUTH_BACKEND=netbox.authentication.LDAPBackend
 
 LDAP_IGNORE_CERT_ERRORS={{ netbox_ldap_ignore_cert_errors }}
 
-AUTH_LDAP_USER_DN_TEMPLATE={{ netbox_ldap_user_dn_template }}
 AUTH_LDAP_START_TLS={{ netbox_ldap_start_tls }}
 AUTH_LDAP_CACHE_TIMEOUT={{ netbox_ldap_cache_timeout }}
 
 AUTH_LDAP_SERVER_URI={{ netbox_ldap_server_uri }}
 AUTH_LDAP_BIND_DN={{ netbox_ldap_bind_dn }}
 AUTH_LDAP_BIND_PASSWORD={{ netbox_ldap_bind_password }}
+
 AUTH_LDAP_USER_SEARCH_BASEDN={{ netbox_ldap_user_search_basedn }}
 AUTH_LDAP_USER_SEARCH_ATTR={{ netbox_ldap_user_search_attr }}
+{% if netbox_ldap_user_dn_template|bool %}AUTH_LDAP_USER_DN_TEMPLATE={{ netbox_ldap_user_dn_template }}{% endif %}
+
 AUTH_LDAP_GROUP_TYPE={{ netbox_ldap_group_type }}
 AUTH_LDAP_GROUP_SEARCH_CLASS={{ netbox_ldap_group_search_class }}
 AUTH_LDAP_GROUP_SEARCH_BASEDN={{ netbox_ldap_group_search_basedn }}
 
-AUTH_LDAP_REQUIRE_GROUP_DN={{ netbox_ldap_require_group_dn }}
-AUTH_LDAP_IS_ADMIN_DN={{ netbox_ldap_is_admin_dn }}
-AUTH_LDAP_IS_SUPERUSER_DN={{ netbox_ldap_is_superuser_dn }}
+{% if netbox_ldap_require_group_dn|bool %}AUTH_LDAP_REQUIRE_GROUP_DN={{ netbox_ldap_require_group_dn }}{% endif %}
+{% if netbox_ldap_is_admin_dn|bool %}AAUTH_LDAP_IS_ADMIN_DN={{ netbox_ldap_is_admin_dn }}{% endif %}
+{% if netbox_ldap_is_superuser_dn|bool %}AAUTH_LDAP_IS_SUPERUSER_DN={{ netbox_ldap_is_superuser_dn }}{% endif %}
 
 AUTH_LDAP_MIRROR_GROUPS={{ netbox_ldap_mirror_groups }}
 AUTH_LDAP_FIND_GROUP_PERMS={{ netbox_ldap_find_group_perms }}


### PR DESCRIPTION
Some environment variables must not be set, if not used.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>