### PR TITLE
Netbox: Template users initializer dictionary

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -150,6 +150,5 @@ netbox_init_groups:
   netbox-readers:
     users: []
 
-netbox_init_users:
-  "{{ netbox_user_name }}":
-    api_token: "{{ netbox_user_api_token }}"
+netbox_init_users_template: "{'{{ netbox_user_name }}': {'api_token': '{{ netbox_user_api_token }}'}}"
+netbox_init_users: "{{ netbox_init_users_template }}"


### PR DESCRIPTION
The dictionary key `netbox_user_name` needs to be evaluated, to substitute
the variable.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>