### PR TITLE
manager: remove REQUESTS_CA_BUNDLE

### DIFF
--- a/roles/manager/templates/env/ansible.env.j2
+++ b/roles/manager/templates/env/ansible.env.j2
@@ -1,4 +1,3 @@
-REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 {% if enable_netbox|bool %}
 NETBOX_API={{ netbox_api_url }}
 {% endif %}


### PR DESCRIPTION
Causes strange errors in the testbed in interaction with
the self-signed certificate from Traefik. Therefore
partial revert of d0d42c1d84dc8b194b48acda43bb348f43f67778
for the moment.

Signed-off-by: Christian Berendt <berendt@osism.tech>