### PR TITLE
chrony: add chrony_bindaddresses parameter

### DIFF
--- a/roles/chrony/defaults/main.yml
+++ b/roles/chrony/defaults/main.yml
@@ -24,5 +24,10 @@ chrony_allowed_subnets:
   - 192.168/16
   - 172.16/12
 
-# Listen for NTP requests only on local interfaces.
+# If set to true, chronyd will never open the server port and will operate
+# strictly in a client-only mode.
 chrony_bind_local_interfaces_only: true
+
+# Bind Chrony to specific addresses
+# NOTE: It is only possible to set at most one IPv4 and one IPv6 address.
+chrony_bindaddresses: []

--- a/roles/chrony/templates/chrony.conf.j2
+++ b/roles/chrony/templates/chrony.conf.j2
@@ -98,9 +98,12 @@ rtcsync
 # change it if necessary.
 rtconutc
 
+{% for chrony_bindaddress in chrony_bindaddresses %}
+bindaddress {{ chrony_bindaddress }}
+{% endfor %}
+
 {% if chrony_bind_local_interfaces_only | bool %}
-# Listen for NTP requests only on local interfaces.
+# If set to 0, chronyd will never open the server port and will operate
+# strictly in a client-only mode.
 port 0
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
 {% endif %}


### PR DESCRIPTION
With the chrony_bindaddresses parameter it is possible to
bind Chrony to specific addresses.

This PR also removes the bindcmdaddress parameters from
the chrony.conf.j2 template as they are set to these
values by default.

Signed-off-by: Christian Berendt <berendt@osism.tech>