### PR TITLE
keycloak: add traefik integration

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -29,6 +29,7 @@ keycloak_port: 8170
 
 keycloak_tag: latest
 keycloak_image: "{{ docker_registry_keycloak }}/keycloak/keycloak:{{ keycloak_tag }}"
+keycloak_for_traefik_image: "{{ docker_registry_keycloak }}/osism/keycloak:{{ keycloak_tag }}"
 
 keycloak_username: admin
 keycloak_password: password
@@ -48,3 +49,14 @@ keycloak_postgres_databasename: keycloak
 
 keycloak_galera_backend_enable: false
 keycloak_use_preconfigured_databases: false
+
+##########################
+# traefik
+
+keycloak_traefik: false
+
+keycloak_traefik_path_prefix: keycloak
+keycloak_traefik_host: ""
+
+traefik_external_network_name: traefik
+traefik_external_network_cidr: 172.31.254.0/24

--- a/roles/keycloak/tasks/service.yml
+++ b/roles/keycloak/tasks/service.yml
@@ -1,4 +1,11 @@
 ---
+- name: Create traefik external network
+  community.general.docker_network:
+    name: "{{ traefik_external_network_name }}"
+    ipam_config:
+      - subnet: "{{ traefik_external_network_cidr }}"
+  when: keycloak_traefik|bool
+
 - name: Copy docker-compose.yml file
   ansible.builtin.template:
     src: docker-compose.yml.j2

--- a/roles/keycloak/templates/docker-compose.yml.j2
+++ b/roles/keycloak/templates/docker-compose.yml.j2
@@ -4,7 +4,11 @@ version: '3.5'
 services:
   keycloak:
     container_name: "{{ keycloak_container_name }}"
+{% if not keycloak_traefik|bool %}
     image: "{{ keycloak_image }}"
+{% else %}
+    image: "{{ keycloak_for_traefik_image }}"
+{% endif %}
     restart: unless-stopped
     env_file:
       - "{{ keycloak_configuration_directory }}/keycloak.env"
@@ -12,8 +16,33 @@ services:
       - /etc/hosts:/etc/hosts:ro
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+{% if not keycloak_traefik|bool %}
     ports:
       - "{{ keycloak_host }}:{{ keycloak_port }}:8080"
+{% else %}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network={{ traefik_external_network_name }}"
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+      - "traefik.http.middlewares.keycloak-redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.keycloak.entrypoints=http"
+{% if keycloak_traefik_host|length > 0 %}
+      - "traefik.http.routers.keycloak.rule=Host(`{{ keycloak_traefik_host }}`) && PathPrefix(`/{{ keycloak_traefik_path_prefix }}/`)"
+{% else %}
+      - "traefik.http.routers.keycloak.rule=PathPrefix(`/{{ keycloak_traefik_path_prefix }}/`)"
+{% endif %}
+      - "traefik.http.routers.keycloak.middlewares=keycloak-redirect-to-https@docker"
+      - "traefik.http.routers.keycloak-secure.entrypoints=https"
+      - "traefik.http.routers.keycloak-secure.tls=true"
+{% if keycloak_traefik_host|length > 0 %}
+      - "traefik.http.routers.keycloak-secure.rule=Host(`{{ keycloak_traefik_host }}`) && PathPrefix(`/{{ keycloak_traefik_path_prefix }}/`)"
+{% else %}
+      - "traefik.http.routers.keycloak-secure.rule=PathPrefix(`/{{ keycloak_traefik_path_prefix }}/`)"
+{% endif %}
+    networks:
+      - default
+      - {{ traefik_external_network_name }}
+{% endif %}
     depends_on:
       - postgres
 {% if not keycloak_galera_backend_enable |bool %}
@@ -47,3 +76,7 @@ networks:
       driver: default
       config:
         - subnet:  {{ keycloak_network }}
+{% if keycloak_traefik|bool %}
+  {{ traefik_external_network_name }}:
+    external: true
+{% endif %}


### PR DESCRIPTION
To use Keycloak behind Traefik, a customized image of
Keycloak is required. This is necessary because the used
path keycloak must be set explicitly in various static
configuration files in the image.

The customized image is maintained in osism/container-images.

Closes #567

Signed-off-by: Christian Berendt <berendt@osism.tech>