### PR TITLE
manager: add netbox parameters to the beat and osismclient services

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -133,11 +133,23 @@ services:
     command: osism beat
     healthcheck:
       test: pgrep celery
+{% if enable_netbox|bool %}
+    secrets:
+      - NETBOX_TOKEN
+    env_file:
+      - "{{ manager_configuration_directory }}/netbox.env"
+{% endif %}
   osismclient:
     container_name: osismclient
     restart: unless-stopped
     image: "{{ osism_image }}"
     command: sleep infinity
+{% if enable_netbox|bool %}
+    secrets:
+      - NETBOX_TOKEN
+    env_file:
+      - "{{ manager_configuration_directory }}/netbox.env"
+{% endif %}
   flower:
     restart: unless-stopped
     image: "{{ osism_image }}"


### PR DESCRIPTION
The netbox parameters will be needed by python-osism in
various places in the future.

Signed-off-by: Christian Berendt <berendt@osism.tech>