### PR TITLE
netbox: add ironic custom fields to the device object

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -58,3 +58,33 @@ deployment_type:
   weight: 0
   on_objects:
     - dcim.models.Device
+
+maintenance:
+  type: boolean
+  label: Maintenance
+  default: false
+  description: Maintenance
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+
+provisioning_state:
+  type: text
+  label: Provisioning state
+  default: ""
+  description: Provisioning state of a device
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+
+power_state:
+  type: text
+  label: Power state
+  default: ""
+  description: Power state of a device
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device


### PR DESCRIPTION
With these custom fields it is possible to store the
state of the systems in Ironic in the Netbox.

It is then possible to filter via the Ansible Inventory
whether a system is already available or not.

Signed-off-by: Christian Berendt <berendt@osism.tech>