### PR TITLE
manager: add listener service

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -318,6 +318,13 @@ manager_environment_extra: {}
 #   REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
 
 ##########################
+# listener
+
+manager_listener_transport_url: "rabbit://openstack:password@127.0.0.1:5672/"
+manager_listener_driver: messagingv2
+manager_listener_topics: notifications
+
+##########################
 # traefik
 
 traefik_external_network_name: traefik

--- a/roles/manager/tasks/config-celery.yml
+++ b/roles/manager/tasks/config-celery.yml
@@ -8,3 +8,13 @@
     sysctl_set: true
     state: present
     reload: true
+
+- name: Copy celery configuration files
+  ansible.builtin.template:
+    src: "celery/{{ item }}.j2"
+    dest: "{{ manager_configuration_directory }}/{{ item }}"
+    mode: 0644
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+  loop:
+    - listener.conf

--- a/roles/manager/templates/celery/listener.conf.j2
+++ b/roles/manager/templates/celery/listener.conf.j2
@@ -1,0 +1,4 @@
+[oslo_messaging_notifications]
+transport_url = {{ manager_listener_transport_url }}
+driver = {{ manager_listener_driver }}
+topics = {{ manager_listener_topics }}

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -106,6 +106,12 @@ services:
       - NETBOX_TOKEN
     env_file:
       - "{{ manager_configuration_directory }}/netbox.env"
+  listener:
+    restart: unless-stopped
+    image: "{{ osism_image }}"
+    command: osism service listener
+    volumes:
+      - "{{ manager_configuration_directory }}/listener.conf:/etc/listener.conf:ro"
 {% endif %}
   watchdog:
     restart: unless-stopped


### PR DESCRIPTION
The listener service is available for evaluating notifications
from OpenStack.

Signed-off-by: Christian Berendt <berendt@osism.tech>