### PR TITLE
manager: resize the manager network

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -23,7 +23,7 @@ docker_network_mtu: 1500
 ##########################
 # generic
 
-manager_network: 172.31.101.0/28
+manager_network: 172.31.101.0/27
 
 manager_service_name: "docker-compose@manager"
 

--- a/roles/virtualbmc/defaults/main.yml
+++ b/roles/virtualbmc/defaults/main.yml
@@ -18,7 +18,7 @@ docker_registry_virtualbmc: quay.io
 virtualbmc_configuration_directory: /opt/virtualbmc/configuration
 virtualbmc_docker_compose_directory: /opt/virtualbmc
 
-virtualbmc_network: 172.31.101.16/28
+virtualbmc_network: 172.31.101.128/28
 virtualbmc_service_name: "docker-compose@virtualbmc"
 
 virtualbmc_host: 127.0.0.1


### PR DESCRIPTION
More IP addresses are needed because the number of
services has increased.

Signed-off-by: Christian Berendt <berendt@osism.tech>