### PR TITLE
netbox: add custom field ironic_state

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -118,3 +118,13 @@ network_interface_name:
   weight: 0
   on_objects:
     - dcim.models.Interface
+
+ironic_state:
+  type: text
+  label: Ironic state
+  default: unregistered
+  description: Is the device available in Ironic
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device


### PR DESCRIPTION
This field records whether a device has already
been registered in Ironic or not.

Signed-off-by: Christian Berendt <berendt@osism.tech>