### PR TITLE
netbox: remove deployment_parameters

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -39,16 +39,6 @@ device_type:
   on_objects:
     - dcim.models.Device
 
-deployment_parameters:
-  type: json
-  label: Deployment parameters
-  default: ""
-  description: Extra parameters for the deployment
-  required: false
-  weight: 0
-  on_objects:
-    - dcim.models.Device
-
 deployment_type:
   type: text
   label: Deployment type


### PR DESCRIPTION
Config Context is used for this purpose.

Signed-off-by: Christian Berendt <berendt@osism.tech>