### PR TITLE
netbox: add ironic_enabled & deployment_enabled custom fields

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -1,4 +1,24 @@
 ---
+deployment_enabled:
+  type: boolean
+  label: Deployment enabled
+  default: false
+  description: Deployment enabled
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+
+ironic_enabled:
+  type: boolean
+  label: Ironic enabled
+  default: false
+  description: Ironic enabled
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+
 configuration_template:
   type: text
   label: Configuration template


### PR DESCRIPTION
With those custom fields it is possible to enable/disable the
deployment and use of a device with ironic.

Signed-off-by: Christian Berendt <berendt@osism.tech>