### PR TITLE
manager: do not enable vault service by default

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -199,8 +199,7 @@ osism_api_port: 8000
 
 vault_container_name: manager_vault_1
 
-enable_vault: "{{ vault_enable }}"
-vault_enable: true
+enable_vault: false
 
 vault_host: "{{ ansible_default_ipv4.address }}"
 vault_port: 8200


### PR DESCRIPTION
Vault is currently not yet integrated. Therefore
it should not be deployed by default at the moment.

Until now, Vault was deployed when AWX was activated.
AWX was activated by default. By removing AWX, the
default for Vault has mistakenly changed from False
to True.

Signed-off-by: Christian Berendt <berendt@osism.tech>