### PR TITLE
traefik: add no_log to the "Copy certificate cert files" task

### DIFF
--- a/roles/traefik/tasks/config.yml
+++ b/roles/traefik/tasks/config.yml
@@ -32,6 +32,7 @@
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
   loop: "{{ traefik_certificates | dict2items }}"
+  no_log: true
 
 - name: Copy certificate key files
   ansible.builtin.copy:


### PR DESCRIPTION
This ensures that no private keys end up in the logs.

Signed-off-by: Christian Berendt <berendt@osism.tech>