### PR TITLE
keycloak: remove keycloak_for_traefik_image

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -29,7 +29,6 @@ keycloak_port: 8170
 
 keycloak_tag: latest
 keycloak_image: "{{ docker_registry_keycloak }}/keycloak/keycloak:{{ keycloak_tag }}"
-keycloak_for_traefik_image: "{{ docker_registry_keycloak }}/osism/keycloak:{{ keycloak_tag }}"
 
 keycloak_username: admin
 keycloak_password: password


### PR DESCRIPTION
Parameter is left and is no longer needed.

Signed-off-by: Christian Berendt <berendt@osism.tech>