### PR TITLE
Add Docker-role to renovate for auto-update the Dockerversion

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,14 @@
       "matchStrings":[
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\n.*?_tag: '(?<currentValue>.*?)'"
      ]
+    },
+    {
+      "fileMatch":[
+        "^roles\\/docker\\/defaults\\/main.yml$",
+      ],
+      "matchStrings":[
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\n.*?docker_version: '5:(?<currentValue>.*?)'"
+      ]
     }
   ]
 }

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -83,6 +83,7 @@ docker_pip_extra_args: ""
 
 # NOTE: This "5:" must be prepended starting with version 18.09.
 #       Check available version under Ubuntu with apt-cache madison docker-ce.
+# renovate: datasource=docker depName=docker
 docker_version: "5:20.10.6"
 
 ##########################


### PR DESCRIPTION
- Add the docker-role to the renovate.json for auto-updating the Docker-Version
- This closes osism/issues#147

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
