### PR TITLE
docker: move become to the top

### DIFF
--- a/roles/docker/tasks/bootstrap.yml
+++ b/roles/docker/tasks/bootstrap.yml
@@ -3,11 +3,11 @@
   meta: flush_handlers
 
 - name: Add user to docker group
+  become: true
   ansible.builtin.user:
     name: "{{ docker_user }}"
     groups: docker
     append: true
-  become: true
 
 # NOTE: use paramiko connection to force a re-login
 

--- a/roles/docker/tasks/config-open-policy-agent.yml
+++ b/roles/docker/tasks/config-open-policy-agent.yml
@@ -1,14 +1,15 @@
 ---
 - name: Create policies directory
+  become: true
   ansible.builtin.file:
     path: /etc/docker/policies
     state: directory
     owner: root
     group: root
     mode: 0750
-  become: true
 
 - name: Copy policy files
+  become: true
   ansible.builtin.template:
     src: "policies/{{ item }}.j2"
     dest: "/etc/docker/policies/{{ item }}"
@@ -16,22 +17,21 @@
     group: root
     mode: 0640
   loop: "{{ docker_policy_files }}"
-  become: true
   notify: Reload docker service
 
 - name: List existing policy files
+  become: true
   ansible.builtin.command: "find /etc/docker/policies/ -type f -printf '%f\n'"
   changed_when: false
   register: existing_policy_files
-  become: true
 
 - name: Remove unmanaged policy files
+  become: true
   ansible.builtin.file:
     dest: "/etc/docker/policies/{{ item }}"
     state: absent
   when: item not in docker_policy_files
   loop: "{{ existing_policy_files.stdout_lines | default([]) }}"
-  become: true
   notify: Reload docker service
 
 - name: Create .docker directory

--- a/roles/docker/tasks/config.yml
+++ b/roles/docker/tasks/config.yml
@@ -6,24 +6,25 @@
     - "'zun-compute' in group_names"
 
 - name: Create plugins directory
+  become: true
   ansible.builtin.file:
     path: /etc/docker/plugins
     state: directory
     owner: root
     group: root
     mode: 0755
-  become: true
 
 - name: Create systemd overlay directory
+  become: true
   ansible.builtin.file:
     path: "/etc/systemd/system/{{ docker_service_name }}.service.d"
     state: directory
     owner: root
     group: root
     mode: 0755
-  become: true
 
 - name: Copy systemd overlay file
+  become: true
   ansible.builtin.template:
     src: overlay.conf.j2
     dest: "/etc/systemd/system/{{ docker_service_name }}.service.d/overlay.conf"
@@ -31,25 +32,25 @@
     group: root
     mode: 0644
   register: systemd_overlay_template
-  become: true
   notify: Restart docker service
 
 - name: Reload systemd daemon if systemd overlay file is changed
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
   when: systemd_overlay_template is changed
-  become: true
 
 - name: Copy limits configuration file
+  become: true
   ansible.builtin.copy:
     src: limits.conf
     dest: /etc/security/limits.d/docker.conf
     owner: root
     group: root
     mode: 0644
-  become: true
 
 - name: Copy daemon.json configuration file
+  become: true
   ansible.builtin.template:
     src: daemon.json.j2
     dest: /etc/docker/daemon.json
@@ -57,7 +58,6 @@
     group: root
     mode: 0644
   notify: Restart docker service
-  become: true
 
 - name: Include open policy agent tasks
   ansible.builtin.include_tasks: config-open-policy-agent.yml

--- a/roles/docker/tasks/install-docker-Debian.yml
+++ b/roles/docker/tasks/install-docker-Debian.yml
@@ -17,30 +17,31 @@
   changed_when: false
 
 - name: Install apt-transport-https package
+  become: true
   ansible.builtin.apt:
     name: apt-transport-https
     state: present
-  become: true
   when: docker_configure_repository|bool
   changed_when: false
 
 - name: Add repository gpg key
+  become: true
   ansible.builtin.apt_key:
     url: "{{ docker_debian_repository_key }}"
-  become: true
   when: docker_configure_repository|bool
 
 - name: Add repository
+  become: true
   ansible.builtin.apt_repository:
     repo: "{{ docker_debian_repository }}"
     state: present
     filename: docker
     update_cache: true
     mode: 0644
-  become: true
   when: docker_configure_repository|bool
 
 - name: Pin package version
+  become: true
   ansible.builtin.copy:
     content: |
       Package: {{ docker_package_name }}
@@ -48,9 +49,9 @@
       Pin-Priority: 1001
     dest: /etc/apt/preferences.d/docker
     mode: 0644
-  become: true
 
 - name: Pin cli package version
+  become: true
   ansible.builtin.copy:
     content: |
       Package: {{ docker_package_name }}-cli
@@ -58,13 +59,12 @@
       Pin-Priority: 1001
     dest: /etc/apt/preferences.d/docker-cli
     mode: 0644
-  become: true
 
 - name: Unlock containerd package
+  become: true
   ansible.builtin.dpkg_selections:
     name: "{{ containerd_package_name }}"
     selection: install
-  become: true
   tags: molecule-idempotence-notest
 
 - name: Wait for apt lock
@@ -76,16 +76,16 @@
 
 # NOTE: At this point the last available version of containerd should be installed
 - name: Install containerd package
+  become: true  # noqa 403
   ansible.builtin.apt:
     name: "{{ containerd_package_name }}"
     state: latest
-  become: true  # noqa 403
 
 - name: Lock containerd package
+  become: true
   ansible.builtin.dpkg_selections:
     name: "{{ containerd_package_name }}"
     selection: hold
-  become: true
   tags: molecule-idempotence-notest
 
 - name: Wait for apt lock
@@ -96,10 +96,10 @@
   changed_when: false
 
 - name: Install docker-cli package
+  become: true
   ansible.builtin.apt:
     name: "{{ docker_cli_package_name }}={{ docker_version }}*"
     state: present
-  become: true
 
 - name: Wait for apt lock
   ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
@@ -109,12 +109,13 @@
   changed_when: false
 
 - name: Install docker package
+  become: true
   ansible.builtin.apt:
     name: "{{ docker_package_name }}={{ docker_version }}*"
     state: present
-  become: true
 
 - name: Install python bindings with apt
+  become: true
   block:
     - name: Unblock installation of python docker packages
       ansible.builtin.file:
@@ -134,10 +135,10 @@
         name: "{{ docker_python3_package_name }}"
         state: present
 
-  become: true
   when: not docker_python_install_from_pip|bool
 
 - name: Install python bindings with pip
+  become: true
   block:
     - name: Wait for apt lock
       ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
@@ -180,7 +181,6 @@
         executable: pip3
         state: present
 
-  become: true
   when: docker_python_install_from_pip|bool
 
 - name: Wait for apt lock
@@ -191,10 +191,10 @@
   changed_when: false
 
 - name: Install packages required by docker login
+  become: true
   ansible.builtin.apt:
     name: ["gnupg2", "pass"]
     state: present
-  become: true
   when:
     - docker_registry_username is defined and docker_registry_username|string|length > 0
     - docker_registry_password is defined and docker_registry_password|string|length > 0

--- a/roles/docker/tasks/install-kata-Debian.yml
+++ b/roles/docker/tasks/install-kata-Debian.yml
@@ -7,26 +7,26 @@
   changed_when: false
 
 - name: Install apt-transport-https package
+  become: true
   ansible.builtin.apt:
     name: apt-transport-https
     state: present
   when: docker_kata_configure_repository|bool
-  become: true
 
 - name: Add repository gpg key
+  become: true
   ansible.builtin.apt_key:
     url: "{{ docker_kata_debian_repository_key }}"
   when: docker_kata_configure_repository|bool
-  become: true
 
 - name: Add repository
+  become: true
   ansible.builtin.apt_repository:
     repo: "{{ docker_kata_debian_repository }}"
     state: present
     filename: kata
     update_cache: true
   when: docker_kata_configure_repository|bool
-  become: true
 
 - name: Wait for apt lock
   ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
@@ -36,7 +36,7 @@
   changed_when: false
 
 - name: Install required packages
+  become: true
   ansible.builtin.apt:
     name: "{{ docker_kata_packages }}"
     state: present
-  become: true

--- a/roles/docker/tasks/install-open-policy-agent.yml
+++ b/roles/docker/tasks/install-open-policy-agent.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install open policy agent plugin
+  become: true
   ansible.builtin.command: |
     docker plugin install --grant-all-permissions {{ docker_open_policy_agent_image }} opa-args="-policy-file /opa/policies/default.rego"
   register: result
-  become: true
   changed_when: "'Installed plugin' in result.stdout"
   failed_when: "result.rc > 0 and 'already exists' not in result.stderr"

--- a/roles/docker/tasks/service.yml
+++ b/roles/docker/tasks/service.yml
@@ -1,23 +1,23 @@
 ---
 - name: Start/enable service
+  become: true
   ansible.builtin.service:
     name: "{{ docker_service_name }}"
     state: started
     enabled: true
-  become: true
 
 - name: Start/enable docker socket service
+  become: true
   ansible.builtin.service:
     name: "{{ docker_service_name }}.socket"
     state: started
     enabled: true
   when: ansible_os_family == 'Debian'
-  become: true
 
 - name: Start/enable containerd service
+  become: true
   ansible.builtin.service:
     name: "{{ containerd_service_name }}"
     state: started
     enabled: true
   when: ansible_os_family == 'Debian'
-  become: true

--- a/roles/docker/tasks/storage.yml
+++ b/roles/docker/tasks/storage.yml
@@ -1,27 +1,27 @@
 ---
 - name: Create filesystem on storage block device
+  become: true
   community.general.filesystem:
     dev: "{{ docker_storage_block_device }}"
     fstype: "{{ docker_storage_filesystem }}"
     force: "{{ docker_storage_force }}"
-  become: true
   ignore_errors: true
 
 - name: Create docker directory
+  become: true
   ansible.builtin.file:
     path: /var/lib/docker
     state: directory
     owner: root
     group: root
     mode: 0711
-  become: true
   tags:
     - skip_ansible_lint
 
 - name: Mount storage block device to docker directory
+  become: true
   ansible.posix.mount:
     path: /var/lib/docker
     src: "{{ docker_storage_block_device }}"
     fstype: "{{ docker_storage_filesystem }}"
     state: mounted
-  become: true


### PR DESCRIPTION
We have the become in the other roles above the task and not
below. Hence the adjustment here.

Signed-off-by: Christian Berendt <berendt@osism.tech>