### PR TITLE
Use the Ansible FQCN´s

### DIFF
--- a/roles/manager/tasks/config-celery.yml
+++ b/roles/manager/tasks/config-celery.yml
@@ -23,7 +23,7 @@
 
 - name: Check for conductor.yml
   delegate_to: localhost
-  stat:
+  ansible.builtin.stat:
     path: "{{ configuration_directory }}/environments/manager/files/conductor.yml"
   register: result
 


### PR DESCRIPTION
- Rename the modules to the ansible FQCN´s
- This is partly: osism/issues#165

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
