### PR TITLE
netbox: wait 120 seconds until the first healthcheck

### DIFF
--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -44,6 +44,7 @@ services:
       - NETBOX_SECRET_KEY
     healthcheck:
       test: curl -s -k http://127.0.0.1:8080/metrics
+      start_period: 120s
 {% if not netbox_traefik|bool %}
     ports:
       - "{{ netbox_host }}:{{ netbox_port }}:8080"


### PR DESCRIPTION
Since the migrations are running at the initial start,
it takes some time until the service is available.

To avoid an unnecessary unhealthy state, perform the
first test only after 120 seconds.

Signed-off-by: Christian Berendt <berendt@osism.tech>