### PR TITLE
cgit: rewrite / to /cgit

### DIFF
--- a/roles/cgit/templates/docker-compose.yml.j2
+++ b/roles/cgit/templates/docker-compose.yml.j2
@@ -29,6 +29,9 @@ services:
       - "traefik.http.routers.cgit-secure.entrypoints=https"
       - "traefik.http.routers.cgit-secure.tls=true"
       - "traefik.http.routers.cgit-secure.rule=Host(`{{ cgit_host }}`)"
+      - "traefik.http.routers.cgit-secure.middlewares=custom_repath"
+      - "traefik.http.middlewares.custom_repath.replacepathregex.regex=^/$$"
+      - "traefik.http.middlewares.custom_repath.replacepathregex.replacement=/cgit/"
     networks:
       - default
       - {{ traefik_external_network_name }}


### PR DESCRIPTION
When you call / the directory listing is currently displayed.
The cgit runs only under /cgit. Therefore / should be rewritten
to /cgit so that the call from / works directly.

Signed-off-by: Christian Berendt <berendt@osism.tech>