### PR TITLE
nexus: fix docker health check

### DIFF
--- a/roles/nexus/templates/docker-compose.yml.j2
+++ b/roles/nexus/templates/docker-compose.yml.j2
@@ -22,7 +22,7 @@ services:
     volumes:
       - "/etc/hosts:/etc/hosts:ro"
     healthcheck:
-      test: curl --silent --fail localhost:8081
+      test: curl --silent --fail localhost:8081/nexus/
     volumes:
       - "data:/nexus-data"
       - "{{ nexus_configuration_directory }}/nexus.properties:/nexus-data/etc/nexus.properties:ro"


### PR DESCRIPTION
The health check needs to use the /nexus/ path to recieve a successful
http return code.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>