### PR TITLE
Make  /lib/systemd/system writeable for ansible, to modify systemd.un…

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -66,6 +66,7 @@ services:
       - "{{ secrets_directory }}:/ansible/secrets:ro"
       - "inventory_reconciler:/ansible/inventory:ro"
       - "interface:/interface"
+      - "/lib/systemd/system:/lib/systemd/system"
 {% if enable_netbox|bool %}
     secrets:
       - NETBOX_TOKEN


### PR DESCRIPTION
Make  /lib/systemd/system writeable for ansible, to modify systemd.unit files
that was detected in cause of tang rollout

"msg": "Destination /lib/systemd/system not writable

Signed-off-by: Mathias Fechner <fechner@osism.tech>