### PR TITLE
tang: remove static port definition

### DIFF
--- a/roles/tang/templates/tangd.socket.conf.j2
+++ b/roles/tang/templates/tangd.socket.conf.j2
@@ -7,13 +7,8 @@ After=tangd-keygen.service
 After=tangd-update.service
 
 [Socket]
-{%- if tang_server_port is string %}
 
 ListenStream={{ tang_server_port }}
-{%- else %}
-
-ListenStream=80
-{% endif %}
 
 Accept=true
 


### PR DESCRIPTION
the default port is already defined in tang defaults
it make no sense to define it generic in template

Signed-off-by: Mathias Fechner <fechner@osism.tech>