### PR TITLE
squid: fix wrong parameter name

### DIFF
--- a/roles/squid/templates/osism_allow_list.conf.j2
+++ b/roles/squid/templates/osism_allow_list.conf.j2
@@ -1,4 +1,4 @@
-{% for address in allowed_addresses %}
+{% for address in squid_allowed_addresses %}
 acl whitelist dstdomain {{ address }}
 {% endfor %}
 http_access allow whitelist


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>