### PR TITLE
wireguard: add wireguard_client_configuration_file

### DIFF
--- a/roles/wireguard/README.rst
+++ b/roles/wireguard/README.rst
@@ -27,6 +27,11 @@ Maximum Transfer Unit for wireguard. Please look which MTU fits for your system.
 
 The client address in the VPN.
 
+.. zuul:rolevar:: wireguard_client_configuration_file
+   :default: wireguard-client.conf
+
+The name of the client configuration file in the operator home directory.
+
 .. zuul:rolevar:: wireguard_allowed_client_ips
    :default: 192.168.16.0/20, 192.168.48.0/20, 192.168.96.0/20, 192.168.112.0/20
 

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -4,6 +4,7 @@ operator_group: "{{ operator_user }}"
 
 wireguard_mtu: 1360
 wireguard_client_address: 192.168.48.4/24
+wireguard_client_configuration_file: wireguard-client.conf
 wireguard_allowed_client_ips: 192.168.16.0/20, 192.168.48.0/20, 192.168.96.0/20, 192.168.112.0/20
 
 wireguard_server_address: 192.168.48.5/20

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -74,7 +74,7 @@
 - name: Copy wireguard-client.conf configuration file
   ansible.builtin.template:
     src: client.conf.j2
-    dest: "{{ operator_home.stdout }}/wireguard-client.conf"
+    dest: "{{ operator_home.stdout }}/{{ wireguard_client_configuration_file }}"
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
     mode: 0600


### PR DESCRIPTION
With the wireguard_client_configuration_file parameter it is
possible to set the name of the configurtion file in the
operator home directory.

Signed-off-by: Christian Berendt <berendt@osism.tech>