### PR TITLE
manager: mount environments/openstack to /etc/openstack

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -142,6 +142,7 @@ services:
     volumes:
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
       - "{{ manager_configuration_directory }}/conductor.yml:/etc/conductor.yml:ro"
+      - "{{ configuration_directory }}/environments/openstack:/etc/openstack:ro"
     secrets:
       - NETBOX_TOKEN
     env_file:


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>