### PR TITLE
Revert molecule version

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,3 +1,3 @@
-molecule==4.0.4
+molecule==4.0.3
 molecule-docker==2.1.0
 Jinja2==3.0.3


### PR DESCRIPTION
Since all Tests run into errors and there are bug reports
in the molecuke repo, we decide in Slack that we revert to
the older version of molecule.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
