### PR TITLE
Homer: Changed color scheme of dark mode.

### DIFF
--- a/roles/homer/templates/config.yml.j2
+++ b/roles/homer/templates/config.yml.j2
@@ -22,17 +22,17 @@ colors:
     card-shadow: rgba(0, 0, 0, 0.1)
     link-hover: "#363636"
   dark:
-    highlight-primary: "#a0292a"
+    highlight-primary: "#1b2024"
     highlight-secondary: "#fd7e14"
-    highlight-hover: "#a0292a"
-    background: "#131313"
-    card-background: "#2b2b2b"
-    text: "#eaeaea"
+    highlight-hover: "#e9c544"
+    background: "#1b2024"
+    card-background: "#49535b"
+    text: "#ebeef2"
     text-header: "#ffffff"
-    text-title: "#fafafa"
-    text-subtitle: "#f5f5f5"
+    text-title: "#ebeef2"
+    text-subtitle: "#d1d6dc"
     card-shadow: rgba(0, 0, 0, 0.4)
-    link-hover: "#ffdd57"
+    link-hover: "#e9c544"
 
 links:
   - name: "Contribute"


### PR DESCRIPTION
closes #893

The color scheme itself is not very ideal. Homer does not offer a very flexible way of changing every individual compoenent.
Therefore sticking to original color scheme in light mode.

Signed-off-by: Larissa Stoffers <stoffers@osism.tech>
Co-authored-by: Tim Beermann <beermann@osism.tech>
