### PR TITLE
netbox: enable netbox_initializers by default

### DIFF
--- a/roles/netbox/README.rst
+++ b/roles/netbox/README.rst
@@ -249,7 +249,8 @@ List of files which contain preconfigured settings for netbox data.
 Additional environment variables for the netbox container.
 
 .. zuul:rolevar:: netbox_plugins_defaults
-   :default: netbox_plugin_osism
+   :default: - netbox_initializers
+             - netbox_plugin_osism
 
 Plugins for Netbox which should be installed at default.
 

--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -87,6 +87,7 @@ netbox_extra: {}
 # RELEASE_CHECK_URL: https://api.github.com/repos/netbox-community/netbox/releases
 
 netbox_plugins_defaults:
+  - netbox_initializers
   - netbox_plugin_osism
 netbox_plugins_extra: []
 #   - netbox_bgp


### PR DESCRIPTION
The initializers where a part of the Docker image and where then extracted into a Netbox plugin. Because of this is it necessary to enable the initializers plugin by default.

Signed-off-by: Christian Berendt <berendt@osism.tech>