### PR TITLE
netbox: add device role loadbalancer

### DIFF
--- a/roles/netbox/templates/initializers/device_roles.yml.j2
+++ b/roles/netbox/templates/initializers/device_roles.yml.j2
@@ -44,6 +44,9 @@
 - name: Firewall
   slug: firewall
   color: Yellow
+- name: Loadbalancer
+  slug: loadbalancer
+  color: Yellow
 - name: Mixed
   slug: mixed
   color: black


### PR DESCRIPTION
We are using dedicated load balancers in a new environment and therefore need this new device type.

Signed-off-by: Christian Berendt <berendt@osism.tech>