### PR TITLE
Remove unused *_traefik_path_prefix & *_traefik_host variables

### DIFF
--- a/roles/cgit/defaults/main.yml
+++ b/roles/cgit/defaults/main.yml
@@ -41,8 +41,5 @@ cgit_repositories: "{{ cgit_repositories_defaults|combine(cgit_repositories_extr
 
 cgit_traefik: false
 
-cgit_traefik_path_prefix: cgit
-cgit_traefik_host: ""
-
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -55,8 +55,5 @@ keycloak_use_preconfigured_databases: false
 
 keycloak_traefik: false
 
-keycloak_traefik_path_prefix: keycloak
-keycloak_traefik_host: ""
-
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24

--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -151,9 +151,6 @@ ara_password: password
 
 ara_server_traefik: false
 
-ara_server_traefik_path_prefix: ara
-ara_server_traefik_host: ""
-
 ara_server_host: "{{ ansible_default_ipv4.address }}"
 ara_server_port: 8120
 

--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -125,9 +125,6 @@ netbox_redis_image: "{{ docker_registry_redis }}/library/redis:{{ netbox_redis_t
 
 netbox_traefik: false
 
-netbox_traefik_path_prefix: netbox
-netbox_traefik_host: ""
-
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24
 

--- a/roles/patchman/defaults/main.yml
+++ b/roles/patchman/defaults/main.yml
@@ -74,7 +74,5 @@ patchman_memcached_image: "{{ docker_registry_memcached }}/library/memcached:{{ 
 
 patchman_traefik: false
 
-patchman_traefik_host: ""
-
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24

--- a/roles/phpmyadmin/defaults/main.yml
+++ b/roles/phpmyadmin/defaults/main.yml
@@ -35,8 +35,5 @@ phpmyadmin_service_name: "docker-compose@phpmyadmin"
 
 phpmyadmin_traefik: false
 
-phpmyadmin_traefik_path_prefix: phpmyadmin
-phpmyadmin_traefik_host: ""
-
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24


### PR DESCRIPTION
In the Nexus role, the parameters are still used in various places. They remain there and are removed with a Followup PR.

Part of osism/ansible-collection-services#720

Signed-off-by: Christian Berendt <berendt@osism.tech>