### PR TITLE
manager: add /opt/state to the conductor service

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -116,6 +116,7 @@ services:
     volumes:
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
       - "{{ manager_configuration_directory }}/conductor.yml:/etc/conductor.yml:ro"
+      - "{{ state_directory }}/conductor:/state:rw"
     secrets:
       - NETBOX_TOKEN
     env_file:


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>