### PR TITLE
manager: add /opt/state to the ara-server service

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -255,6 +255,7 @@ services:
       - /etc/hosts:/etc/hosts:ro
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+      - "{{ state_directory }}/ara-server:/state:rw"
 {% if not ara_server_traefik|bool %}
     ports:
       - "{{ ara_server_host }}:{{ ara_server_port }}:8000"


### PR DESCRIPTION
This allows a persistent local directory to be used for storage when using SQLite as the DB backend.

Signed-off-by: Christian Berendt <berendt@osism.tech>