### PR TITLE
Refactor wireguard role to allow multiple clients

### DIFF
--- a/roles/wireguard/README.rst
+++ b/roles/wireguard/README.rst
@@ -1,58 +1,39 @@
-An ansible role for installation and configuration wireguard.
+An ansible role for installation and configuration of wireguard. Sets
+up VPN service for a set of local users.
 
 **Role Variables**
 
-.. zuul:rolevar:: operator_user
-   :default: dragon
+.. zuul:rolevar:: wireguard_users
 
-The user that will own the client config.
+List of users that will be configured for access. Each item is a dict with keys::
 
-.. zuul:rolevar:: operator_group
-   :default: operator_user
-
-The group that will own the client config.
-
-.. zuul:rolevar:: wireguard_service_name
-   :default: wg-quick@wg0.service
-
-The name for the wireguard service.
+  - name: Name of the user
+  - key: The public wireguard key of the user
+  - ip: The IP address assigned to the user
 
 .. zuul:rolevar:: wireguard_mtu
    :default: 1360
 
-Maximum Transfer Unit for wireguard. Please look which MTU fits for your system.
-
-.. zuul:rolevar:: wireguard_client_address
-   :default: 192.168.48.4/24
-
-The client address in the VPN.
-
-.. zuul:rolevar:: wireguard_client_configuration_file
-   :default: wireguard-client.conf
-
-The name of the client configuration file in the operator home directory.
-
-.. zuul:rolevar:: wireguard_allowed_client_ips
-   :default: 192.168.16.0/20, 192.168.48.0/20, 192.168.96.0/20, 192.168.112.0/20
-
-Addresses which should be routed through the VPN.
+Maximum Transfer Unit for wireguard. The default should allow connections to work
+through most consumer and cloud networks.
 
 .. zuul:rolevar:: wireguard_server_address
-   :default: 192.168.48.5/20
+   :default: 192.168.48.254/24
 
-The internal VPN server address.
+The VPN server address.
 
 .. zuul:rolevar:: wireguard_listen_port
    :default: 51820
 
 The port on which the wireguard server is listening.
 
-.. zuul:rolevar:: wireguard_allowed_server_ips
-   :default: 192.168.48.0/20
-
-The range of allowed client IP addresses.
-
 .. zuul:rolevar:: wireguard_server_public_address
    :default: WIREGUARD_PUBLIC_IP_ADDRESS
 
-The public IP address of the wireguard server.
+The public IP address of the wireguard server that clients can connect to.
+
+.. zuul:rolevar:: wireguard_create_client_config
+   :default: false
+
+Whether to create client config files. Assumes the user names to be local
+on the server and their home directory to be `/home/user.name`.

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,15 +1,9 @@
 ---
-operator_user: dragon
-operator_group: "{{ operator_user }}"
-
+wireguard_users: []
 wireguard_mtu: 1360
-wireguard_client_address: 192.168.48.4/24
-wireguard_client_configuration_file: wireguard-client.conf
-wireguard_allowed_client_ips: 192.168.16.0/20, 192.168.48.0/20, 192.168.96.0/20, 192.168.112.0/20
-
-wireguard_server_address: 192.168.48.5/20
+wireguard_server_address: 192.168.48.254/24
 wireguard_listen_port: 51820
-wireguard_allowed_server_ips: 192.168.48.0/20
-wireguard_service_name: wg-quick@wg0.service
 wireguard_server_public_address: WIREGUARD_PUBLIC_IP_ADDRESS
 wireguard_endpoint: "{{ wireguard_server_public_address }}:{{ wireguard_listen_port }}"
+wireguard_create_client_config: false
+wireguard_client_allowed_ips: 192.168.16.0/20

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-# NOTE: Errors are ignored because the kernel module may not be available
-#       after initial installation until after a reboot.
 - name: Restart wg0 service
   become: true
   ansible.builtin.systemd:
-    name: "{{ wireguard_service_name }}"
+    name: wg-quick@wg0.service
     state: restarted
-  failed_when: false

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -2,19 +2,9 @@
 - name: Install wireguard package
   become: true
   ansible.builtin.apt:
-    name: wireguard
+    name: wireguard-tools
     state: present
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
-
-- name: Create public and private key - client
-  become: true
-  ansible.builtin.shell: |
-    set -o pipefail
-    umask 077
-    wg genkey | tee /etc/wireguard/client.key | wg pubkey > /etc/wireguard/client.pub
-  args:
-    creates: /etc/wireguard/client.key
-    executable: /bin/bash
 
 - name: Create public and private key - server
   become: true
@@ -36,49 +26,21 @@
   become: true
   ansible.builtin.slurp:
     src: /etc/wireguard/osism.psk
-  register: preshared_key
-
-- name: Get public key - client
-  become: true
-  ansible.builtin.slurp:
-    src: /etc/wireguard/client.pub
-  register: public_key_client
-
-- name: Get private key - client
-  become: true
-  ansible.builtin.slurp:
-    src: /etc/wireguard/client.key
-  register: private_key_client
+  register: wireguard_preshared_key
+  no_log: true
 
 - name: Get public key - server
   become: true
   ansible.builtin.slurp:
     src: /etc/wireguard/server.pub
-  register: public_key_server
+  register: wireguard_public_key_server
 
 - name: Get private key - server
   become: true
   ansible.builtin.slurp:
     src: /etc/wireguard/server.key
-  register: private_key_server
-
-- name: Get home directory of operator user
-  become: true
-  ansible.builtin.shell: |
-    set -o pipefail
-    getent passwd {{ operator_user }} | cut -d: -f6
-  args:
-    executable: /bin/bash
-  changed_when: false
-  register: operator_home
-
-- name: Copy wireguard-client.conf configuration file
-  ansible.builtin.template:
-    src: client.conf.j2
-    dest: "{{ operator_home.stdout }}/{{ wireguard_client_configuration_file }}"
-    owner: "{{ operator_user }}"
-    group: "{{ operator_group }}"
-    mode: 0600
+  register: wireguard_private_key_server
+  no_log: true
 
 - name: Copy wg0.conf configuration file
   become: true
@@ -87,15 +49,22 @@
     dest: /etc/wireguard/wg0.conf
     owner: root
     group: root
-    mode: 0600
+    mode: 0400
   notify: Restart wg0 service
 
-# NOTE: Errors are ignored because the kernel module may not be available
-#       after initial installation until after a reboot.
-- name: Start/enable wg-quick@wg0.service service
+- name: Copy client configuration files
+  become: true
+  ansible.builtin.template:
+    src: client.conf.j2
+    dest: "/home/{{ item.name }}/wg0-{{ item.name }}.conf"
+    owner: "{{ item.name }}"
+    group: "{{ item.name }}"
+    mode: 0600
+  loop: "{{ wireguard_users }}"
+
+- name: Start and enable wg-quick@wg0.service service
   become: true
   ansible.builtin.systemd:
-    name: "{{ wireguard_service_name }}"
+    name: wg-quick@wg0.service
     state: started
     enabled: true
-  failed_when: false

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -1,10 +1,10 @@
 [Interface]
 MTU = {{ wireguard_mtu }}
-PrivateKey = {{ private_key_client['content']|b64decode }}
-Address = {{ wireguard_client_address }}
+PrivateKey = CHANGEME - {{ item.name }} private key
+Address = {{ item.ip }}
 
 [Peer]
-PublicKey = {{ public_key_server['content']|b64decode }}
-PresharedKey = {{ preshared_key['content']|b64decode }}
-AllowedIPs = {{ wireguard_allowed_client_ips }}
+PublicKey = {{ wireguard_public_key_server['content']|b64decode }}
+PresharedKey = {{ wireguard_preshared_key['content']|b64decode }}
+AllowedIPs = {{ wireguard_client_allowed_ips }}
 Endpoint = {{ wireguard_endpoint }}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -1,11 +1,14 @@
 [Interface]
 Address = {{ wireguard_server_address }}
 ListenPort = {{ wireguard_listen_port }}
-PrivateKey = {{ private_key_server['content']|b64decode }}
+PrivateKey = {{ wireguard_private_key_server['content']|b64decode }}
 PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT
+{% for user in wireguard_users %}
 
 [Peer]
-PublicKey = {{ public_key_client['content']|b64decode }}
-PresharedKey = {{ preshared_key['content']|b64decode }}
-AllowedIPs = {{ wireguard_allowed_server_ips }}
+# User {{ user.name }}
+PublicKey = {{ user.key }}
+PresharedKey = {{ wireguard_preshared_key['content']|b64decode }}
+AllowedIPs = {{ user.ip }}
+{% endfor %}


### PR DESCRIPTION
In a production environment, we want to allow for multiple users to be able to connect to the wireguard VPN simultaneously, so we add the option to create a peer configuration for each of them.

Also adapt the role to running on recent Ubuntu versions, where the module is available in the kernel by default.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>