### PR TITLE
manager: add /interface to the osismclient container

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -267,6 +267,7 @@ services:
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
       - "/etc/timezone:/etc/timezone:ro"
       - "cache:{{ cache_directory }}"
+      - "interface:/interface:ro"
       - "inventory_reconciler:/ansible/inventory:ro"
       - "{{ configuration_directory }}:/opt/configuration:ro"
       - "{{ secrets_directory }}:/ansible/secrets:ro"


### PR DESCRIPTION
Required to be able to e.g. read available playbooks

Signed-off-by: Christian Berendt <berendt@osism.tech>