### PR TITLE
docker: add docker_facts argument

### DIFF
--- a/roles/docker/README.rst
+++ b/roles/docker/README.rst
@@ -397,3 +397,8 @@ Fact files for Docker images and containers.
 
 Manage the containerd service with this role. Alternatively, osism.service.containerd
 can be used for this.
+
+.. zuul:rolevar:: docker_facts
+   :default: true
+
+Copy docker fact files.

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -214,6 +214,8 @@ docker_opts: {}
 ##########################
 # facts
 
+docker_facts: true
+
 docker_fact_files:
   - docker_containers
   - docker_images

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -26,3 +26,4 @@
 
 - name: Include facts tasks
   ansible.builtin.include_tasks: facts.yml
+  when: docker_facts|bool


### PR DESCRIPTION
With the docker_facts argument it is possible to disable the docker fact files.

Signed-off-by: Christian Berendt <berendt@osism.tech>