### PR TITLE
Update container versions in zuul role

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -64,20 +64,20 @@ tenants:
 
 docker_registry: index.docker.io
 
-zuul_nodepool_tag: "8.0.0"
-zuul_zookeeper_tag: "3.7.1"
-zuul_tag: "8.0.1"
-zuul_mariadb_tag: "10.6"
 zuul_log_server_tag: "alpine"
+zuul_mariadb_tag: "10.6"
+zuul_nodepool_tag: "8.1.0"
+zuul_zookeeper_tag: "3.7.1"
+zuul_zuul_tag: "8.1.0"
 
+zuul_executor_image: "{{ docker_registry }}/zuul/zuul-executor:{{ zuul_zuul_tag }}"
+zuul_log_server_image: "{{ docker_registry }}/httpd:{{ zuul_log_server_tag }}"
+zuul_mariadb_image: "{{ docker_registry }}/mariadb:{{ zuul_mariadb_tag }}"
 zuul_nodepool_builder_image: "{{ docker_registry }}/zuul/nodepool-builder:{{ zuul_nodepool_tag }}"
 zuul_nodepool_launcher_image: "{{ docker_registry }}/zuul/nodepool-launcher:{{ zuul_nodepool_tag }}"
-zuul_executor_image: "{{ docker_registry }}/zuul/zuul-executor:{{ zuul_tag }}"
-zuul_web_image: "{{ docker_registry }}/zuul/zuul-web:{{ zuul_tag }}"
-zuul_scheduler_image: "{{ docker_registry }}/zuul/zuul-scheduler:{{ zuul_tag }}"
+zuul_scheduler_image: "{{ docker_registry }}/zuul/zuul-scheduler:{{ zuul_zuul_tag }}"
+zuul_web_image: "{{ docker_registry }}/zuul/zuul-web:{{ zuul_zuul_tag }}"
 zuul_zookeeper_image: "{{ docker_registry }}/zookeeper:{{ zuul_zookeeper_tag }}"
-zuul_mariadb_image: "{{ docker_registry }}/mariadb:{{ zuul_mariadb_tag }}"
-zuul_log_server_image: "{{ docker_registry }}/httpd:{{ zuul_log_server_tag }}"
 
 database:
   user_name: zuul


### PR DESCRIPTION
Rename zuul_tag variable to zuul_zuul_tag for consistency. Keep definition blocks in alphabetic ordering.