### PR TITLE
hddtemp: use lm-sensors on Ubuntu 22.04

### DIFF
--- a/roles/hddtemp/README.rst
+++ b/roles/hddtemp/README.rst
@@ -1,17 +1,7 @@
-With this role you can install and configure Hddtmp.
+With this role you can install and configure hddtmp/lm-sensors.
 This tool checks the temperature of a block device.
 
 **Role Variables**
-
-.. zuul:rolevar:: hddtemp_package_name
-   :default: hddtemp
-
-The package name which is needed for the Hddtemp installation.
-
-.. zuul:rolevar:: hddtemp_service_name
-   :default: hddtemp
-
-Service name of Hddtmp.
 
 .. zuul:rolevar:: hddtemp_conf_file
 

--- a/roles/hddtemp/defaults/main.yml
+++ b/roles/hddtemp/defaults/main.yml
@@ -1,6 +1,1 @@
 ---
-##########################
-# hddtemp
-
-hddtemp_package_name: hddtemp
-hddtemp_service_name: hddtemp

--- a/roles/hddtemp/handlers/main.yml
+++ b/roles/hddtemp/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Restart hddtemp service
   become: true
   ansible.builtin.service:
-    name: "{{ hddtemp_service_name }}"
+    name: hddtemp
     state: restarted

--- a/roles/hddtemp/tasks/install-Debian.yml
+++ b/roles/hddtemp/tasks/install-Debian.yml
@@ -9,6 +9,26 @@
 - name: Install hddtemp package
   become: true
   ansible.builtin.apt:
-    name: "{{ hddtemp_package_name }}"
+    name: hddtemp
     state: present
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
+  when:
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Remove hddtemp package
+  become: true
+  ansible.builtin.apt:
+    name: hddtemp
+    state: absent 
+    lock_timeout: "{{ apt_lock_timeout|default(300) }}"
+  when:
+    - ansible_distribution_version is version('22.04', '>=')
+
+- name: Install lm-sensors
+  become: true
+  ansible.builtin.apt:
+    name: lm-sensors
+    state: present
+    lock_timeout: "{{ apt_lock_timeout|default(300) }}"
+  when:
+    - ansible_distribution_version is version('22.04', '>=')

--- a/roles/hddtemp/tasks/install-RedHat.yml
+++ b/roles/hddtemp/tasks/install-RedHat.yml
@@ -2,5 +2,5 @@
 - name: Install hddtemp package
   become: true
   ansible.builtin.dnf:
-    name: ["epel-release", "{{ hddtemp_package_name }}"]
+    name: ["epel-release", "hddtemp"]
     state: present

--- a/roles/hddtemp/tasks/main.yml
+++ b/roles/hddtemp/tasks/main.yml
@@ -5,19 +5,5 @@
 - name: Include distribution specific install tasks
   ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
-- name: Copy hddtemp configuration file
-  become: true
-  ansible.builtin.copy:
-    src: "{{ ansible_os_family }}/hddtemp"
-    dest: "{{ hddtemp_conf_file }}"
-    owner: root
-    group: root
-    mode: 0644
-  notify: Restart hddtemp service
-
-- name: Start/enable hddtemp service
-  become: true
-  ansible.builtin.service:
-    name: "{{ hddtemp_service_name }}"
-    state: started
-    enabled: true
+- name: Include distribution specific service tasks
+  ansible.builtin.include_tasks: "service-{{ ansible_os_family }}.yml"

--- a/roles/hddtemp/tasks/service-Debian.yml
+++ b/roles/hddtemp/tasks/service-Debian.yml
@@ -1,0 +1,30 @@
+---
+- name: Copy hddtemp configuration file
+  become: true
+  ansible.builtin.copy:
+    src: "{{ ansible_os_family }}/hddtemp"
+    dest: "{{ hddtemp_conf_file }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart hddtemp service
+  when:
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Start/enable hddtemp service
+  become: true
+  ansible.builtin.service:
+    name: hddtemp
+    state: started
+    enabled: true
+  when:
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Start/enable lm-sensors service
+  become: true
+  ansible.builtin.service:
+    name: lm-sensors
+    state: started
+    enabled: true
+  when:
+    - ansible_distribution_version is version('22.04', '>=')

--- a/roles/hddtemp/tasks/service-RedHat.yml
+++ b/roles/hddtemp/tasks/service-RedHat.yml
@@ -1,0 +1,17 @@
+---
+- name: Copy hddtemp configuration file
+  become: true
+  ansible.builtin.copy:
+    src: "{{ ansible_os_family }}/hddtemp"
+    dest: "{{ hddtemp_conf_file }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart hddtemp service
+
+- name: Start/enable hddtemp service
+  become: true
+  ansible.builtin.service:
+    name: hddtemp
+    state: started
+    enabled: true


### PR DESCRIPTION
Closes osism/ansible-collection-services#822