### PR TITLE
Role cephclient: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/cephclient/tasks/package-Debian.yml
+++ b/roles/cephclient/tasks/package-Debian.yml
@@ -14,13 +14,6 @@
     mode: 0644
   when: cephclient_configure_repository|bool
 
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install required packages
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
