### PR TITLE
Role chrony: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/chrony/tasks/install-Debian.yml
+++ b/roles/chrony/tasks/install-Debian.yml
@@ -1,11 +1,4 @@
 ---
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install package
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
