### PR TITLE
Role containerd: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/containerd/tasks/install-Debian.yml
+++ b/roles/containerd/tasks/install-Debian.yml
@@ -9,13 +9,6 @@
   when: "item in ansible_facts.packages"
   loop: "{{ containerd_packages_fail }}"
 
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:
@@ -46,13 +39,6 @@
     name: "{{ containerd_package_name }}"
     selection: install
   tags: molecule-idempotence-notest
-
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
 
 # NOTE: At this point the last available version of containerd should be installed
 - name: Install containerd package


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
