### PR TITLE
Role openstackclient: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/openstackclient/tasks/package-Debian.yml
+++ b/roles/openstackclient/tasks/package-Debian.yml
@@ -15,13 +15,6 @@
     mode: 0644
   when: openstackclient_configure_repository|bool
 
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install required packages
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
