### PR TITLE
docker: allow downgrade of docker* packages

### DIFF
--- a/roles/docker/tasks/install-docker-Debian.yml
+++ b/roles/docker/tasks/install-docker-Debian.yml
@@ -109,6 +109,7 @@
     name: "{{ docker_cli_package_name }}={{ docker_version }}*"
     state: present
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
+    allow_downgrade: true
 
 - name: Install docker package
   become: true
@@ -116,6 +117,7 @@
     name: "{{ docker_package_name }}={{ docker_version }}*"
     state: present
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
+    allow_downgrade: true
 
 - name: Install python bindings with apt
   become: true


### PR DESCRIPTION
Since we allow pinning the version of Docker* packages, it may happen that we explicitly want to perform a downgrade. Accordingly, a downgrade must be allowed.

Closes osism/issues#463