### PR TITLE
squid: update allowed addresses

### DIFF
--- a/roles/squid/defaults/main.yml
+++ b/roles/squid/defaults/main.yml
@@ -31,9 +31,9 @@ squid_container_name: squid
 squid_allowed_addresses:
   - harbor.services.osism.tech
   - index.docker.io
-  - quay.io
+  - .quay.io
   - minio.services.osism.tech
-  - archive.ubuntu.com
+  - .archive.ubuntu.com
   - download.docker.com
   - packagecloud.io
   - github.com


### PR DESCRIPTION
Both quay.io and archive.ubuntu.com have subdomains that may be used in downloading content, like cdn03.quay.io and de.archive.ubuntu.com. Allow all subdomains to avoid blocking things.