### PR TITLE
squid: add .cloudfront.net to whitelist

### DIFF
--- a/roles/squid/defaults/main.yml
+++ b/roles/squid/defaults/main.yml
@@ -40,3 +40,4 @@ squid_allowed_addresses:
   - galaxy.ansible.com
   - pypi.org
   - .opendev.org
+  - .cloudfront.net


### PR DESCRIPTION
Packagecloud.io uses Cloudfront as a CDN. Since this is done via HTTP redirect, a whitelist entry is necessary.