### PR TITLE
manager: add share volume to the osismclient service

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -271,6 +271,7 @@ services:
       - "cache:{{ cache_directory }}"
       - "interface:/interface:ro"
       - "inventory_reconciler:/ansible/inventory:ro"
+      - "share:/share"
       - "{{ configuration_directory }}:/opt/configuration:ro"
       - "{{ secrets_directory }}:/ansible/secrets:ro"
 


### PR DESCRIPTION
Required to share keys with the *-ansible containers.