### PR TITLE
manager: set executable for "Wait for an healthy manager service"

### DIFF
--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -35,6 +35,8 @@
                 --filter "label=com.docker.compose.project=manager" \
                 --filter "health=unhealthy"; }' | \
     sort | uniq -u
+  args:
+    executable: /bin/bash
   register: result
   changed_when: false
   until: "result.stdout | length == 0"


### PR DESCRIPTION
By default /bin/sh is used. To be able to use -o pipefail the
use of /bin/bash is required.

Signed-off-by: Christian Berendt <berendt@osism.tech>
