### PR TITLE
Always use supported ansible version

### DIFF
--- a/roles/manager/templates/wrapper/osism-update-manager.j2
+++ b/roles/manager/templates/wrapper/osism-update-manager.j2
@@ -29,19 +29,17 @@ fi
 
 pushd $CONFIGURATION_DIRECTORY/environments/manager > /dev/null
 
-if [[ ! -x "$(command -v ansible-playbook)" ]]; then
-    if [[ ! -e $VENV_PATH ]]; then
+if [[ ! -e $VENV_PATH ]]; then
 
-        if [[ ! -x "$(command -v virtualenv)" ]]; then
-            sudo apt-get install -y virtualenv
-        fi
-
-        virtualenv -p $PYTHON_EXECUTABLE $VENV_PATH
-        source $VENV_PATH/bin/activate
-        pip3 install --no-cache-dir "$ANSIBLE_VERSION" "$NETADDR_VERSION"
-    else
-        source $VENV_PATH/bin/activate
+    if [[ ! -x "$(command -v virtualenv)" ]]; then
+        sudo apt-get install -y virtualenv
     fi
+
+    virtualenv -p $PYTHON_EXECUTABLE $VENV_PATH
+    source $VENV_PATH/bin/activate
+    pip3 install --no-cache-dir "$ANSIBLE_VERSION" "$NETADDR_VERSION"
+else
+    source $VENV_PATH/bin/activate
 fi
 
 if [[ $INSTALL_ANSIBLE_ROLES == "true" ]]; then


### PR DESCRIPTION
As ansible runs in this script only in a virtual env it could pinned
to the supported version.
Close osism/issues#543

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
