### PR TITLE
netbox: avoid restart when service was started via ansible.builtin.se…

### DIFF
--- a/roles/netbox/README.rst
+++ b/roles/netbox/README.rst
@@ -37,6 +37,12 @@ Name of the registry for the Postgres container image.
 
 Name of the registry for the Redis container image.
 
+.. zuul:rolevar:: netbox_service_restart
+   :default: true
+
+Controls the behavior of the restart handler. If set to false the netbox service
+will not restart even if the handler was triggered.
+
 
 **Variables for Netbox**
 

--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -36,6 +36,8 @@ netbox_userid: 101
 netbox_tag: 'v3.4.8'
 netbox_image: "{{ docker_registry_netbox }}/osism/netbox:{{ netbox_tag }}"
 
+netbox_service_restart: true
+
 netbox_secret_key: 00000000-0000-0000-0000-000000000000
 
 netbox_superuser_name: admin

--- a/roles/netbox/handlers/main.yml
+++ b/roles/netbox/handlers/main.yml
@@ -1,6 +1,13 @@
 ---
+# NOTE: This handler prevents a netbox restart when the service
+# was already started via ansible.builtin.service.
+- name: Register that netbox service was started
+  ansible.builtin.set_fact:
+    netbox_service_restart: false
+
 - name: Restart netbox service
   become: true
   ansible.builtin.service:
     name: "{{ netbox_service_name }}"
     state: restarted
+  when: netbox_service_restart|bool

--- a/roles/netbox/tasks/service.yml
+++ b/roles/netbox/tasks/service.yml
@@ -21,3 +21,4 @@
     name: "{{ netbox_service_name }}"
     state: started
     enabled: true
+  notify: Register that netbox service was started


### PR DESCRIPTION
…rvice

This will avoid problems with the initial database bootstrap.