### PR TITLE
manager: increase wait for healty services

### DIFF
--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -40,8 +40,11 @@
   register: result
   changed_when: false
   until: "result.stdout | length == 0"
-  retries: 30
-  delay: 10
+  # NOTE: Netbox availability sometimes takes a long time. Since the inventory
+  #       reconciler is only healthy when the Netbox is usable, a very long wait
+  #       (1000 seconds) is intentionally made here.
+  retries: 50
+  delay: 20
 
 - name: Copy osismclient bash completion script
   become: true


### PR DESCRIPTION
Netbox availability sometimes takes a long time. Since the inventory reconciler is only healthy when the Netbox is usable, a very long wait (1000 seconds) is intentionally made here.