### PR TITLE
manager: add /var/run/docker.sock to osismclient

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -268,6 +268,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
       - "/etc/timezone:/etc/timezone:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "cache:{{ cache_directory }}"
       - "interface:/interface:ro"
       - "inventory_reconciler:/ansible/inventory:ro"


### PR DESCRIPTION
Required to be able to inspect running containers on the manager itself.