### PR TITLE
netbox: support use of an init.sql file

### DIFF
--- a/roles/netbox/README.rst
+++ b/roles/netbox/README.rst
@@ -233,21 +233,10 @@ Cache time span before an information becomes invalid if there is no connection 
 
 Configures, if netbox should offer a metrics endpoint which can be monitored.
 
-.. zuul:rolevar:: netbox_initializers
-   :default: - custom_fields
-             - device_roles
-             - device_types
-             - groups
-             - manufacturers
-             - object_permissions
-             - prefix_vlan_roles
-             - sites
-             - tags
-             - users
-             - webhooks
+.. zuul:rolevar:: netbox_max_db_wait_time
+   :default: 90
 
-List of files which contain preconfigured settings for netbox data.
-(Like device types, custom fields, etc.)
+Time to wait for the database.
 
 .. zuul:rolevar:: netbox_extra
    :default: {}
@@ -288,7 +277,7 @@ Configuration for all Plugins of netbox.
 **Postgres Variables**
 
 .. zuul:rolevar:: postgres_tag
-   :default: 14.3-alpine
+   :default: 15.3-alpine
 
 Version of Postgres which should be used.
 
@@ -312,6 +301,11 @@ Username for the Netbox-Postgres database.
 
 Name for the Netbox-Postgres database.
 
+.. zuul:rolevar:: netbox_postgres_init_sql
+   :default: "{{ configuration_directory }}/environments/infrastructure/files/netbox/init.sql"
+
+Optional init.sql file in the configuration repository that should be used to initialize
+the database.
 
 **Redis Variables**
 
@@ -345,6 +339,27 @@ The Traefik network segment for external traffic.
 
 
 **Initializers Variables**
+
+.. zuul:rolevar:: netbox_init
+   :default: true
+
+Copy and run initialize scripts.
+
+.. zuul:rolevar:: netbox_initializers
+   :default: - custom_fields
+             - device_roles
+             - device_types
+             - groups
+             - manufacturers
+             - object_permissions
+             - prefix_vlan_roles
+             - sites
+             - tags
+             - users
+             - webhooks
+
+List of files which contain preconfigured settings for netbox data.
+(Like device types, custom fields, etc.)
 
 .. zuul:rolevar:: netbox_init_object_permissions
 

--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+configuration_directory: /opt/configuration
+
 ##########################
 # operator
 
@@ -70,19 +72,7 @@ netbox_ldap_find_group_perms: true
 netbox_ldap_cache_timeout: 3600
 
 netbox_metrics: "True"
-
-netbox_initializers:
-  - custom_fields
-  - device_roles
-  - device_types
-  - groups
-  - manufacturers
-  - object_permissions
-  - prefix_vlan_roles
-  - sites
-  - tags
-  - users
-  - webhooks
+netbox_max_db_wait_time: 90
 
 netbox_extra: {}
 # BASE_PATH: netbox/
@@ -115,6 +105,8 @@ netbox_postgres_password: password
 netbox_postgres_username: netbox
 netbox_postgres_databasename: netbox
 
+netbox_postgres_init_sql:  "{{ configuration_directory }}/environments/infrastructure/files/netbox/init.sql"
+
 ##########################
 # redis
 
@@ -132,6 +124,21 @@ traefik_external_network_cidr: 172.31.254.0/24
 
 ##############
 # initializers
+
+netbox_init: true
+
+netbox_initializers:
+  - custom_fields
+  - device_roles
+  - device_types
+  - groups
+  - manufacturers
+  - object_permissions
+  - prefix_vlan_roles
+  - sites
+  - tags
+  - users
+  - webhooks
 
 netbox_init_object_permissions:
   read_write_all:

--- a/roles/netbox/tasks/config-netbox.yml
+++ b/roles/netbox/tasks/config-netbox.yml
@@ -75,6 +75,7 @@
     group: "{{ operator_group }}"
   loop: "{{ netbox_initializers }}"
   notify: Restart netbox service
+  when: netbox_init|bool
 
 # NOTE: Workaround until scripts are available upstream
 - name: Deploy startup scripts for netbox

--- a/roles/netbox/tasks/config-postgres.yml
+++ b/roles/netbox/tasks/config-postgres.yml
@@ -30,6 +30,21 @@
     group: "{{ operator_group }}"
     mode: 0755
 
+- name: Check if init.sql file exists
+  ansible.builtin.stat:
+    path: "{{ netbox_postgres_init_sql }}"
+  register: netbox_postgres_init_sql_check
+
+# NOTE: init.sql.osism to be able to execute the file with our own 
+#       init-netbox-database.sh script
+- name: Copy init.sql file
+  ansible.builtin.copy:
+    src: "{{ netbox_postgres_init_sql }}"
+    dest: "{{ netbox_configuration_directory }}/docker-entrypoint-initdb.d/init.sql.osism"
+    mode: 0644
+  when:
+    - netbox_postgres_init_sql_check.stat.exists
+
 - name: Create init-netbox-database.sh script
   ansible.builtin.template:
     src: config-netbox-database.j2

--- a/roles/netbox/templates/config-netbox-database.j2
+++ b/roles/netbox/templates/config-netbox-database.j2
@@ -7,3 +7,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   GRANT ALL PRIVILEGES ON DATABASE {{ netbox_postgres_databasename }} TO {{ netbox_postgres_username }};
   ALTER DATABASE {{ netbox_postgres_databasename }} OWNER TO {{ netbox_postgres_username }};
 EOSQL
+
+if [[ -e /docker-entrypoint-initdb.d/init.sql.osism ]]; then
+    cat /docker-entrypoint-initdb.d/init.sql.osism | psql -v ON_ERROR_STOP=1 --username netbox --dbname netbox
+fi

--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -11,7 +11,8 @@ services:
     secrets:
       - POSTGRES_PASSWORD
     healthcheck:
-      test: pg_isready -U postgres
+      test: pg_isready -U netbox
+      start_period: 30s
 
   redis:
     restart: unless-stopped
@@ -36,9 +37,11 @@ services:
     volumes:
       - "{{ netbox_configuration_directory }}/configuration.py:/etc/netbox/config/configuration.py:ro"
       - "{{ netbox_configuration_directory }}/nginx-unit.json:/etc/unit/nginx-unit.json:ro"
+{% if netbox_init|bool %}
       - "{{ netbox_configuration_directory }}/initializers:/opt/netbox/initializers:ro"
       # NOTE: Workaround until script is available upstream
       - "{{ netbox_configuration_directory }}/startup-scripts/270_tags.py:/opt/netbox/startup_scripts/270_tags.py:ro"
+{% endif %}
     secrets:
       - NETBOX_POSTGRES_PASSWORD
       - NETBOX_SECRET_KEY

--- a/roles/netbox/templates/env/netbox.env.j2
+++ b/roles/netbox/templates/env/netbox.env.j2
@@ -4,6 +4,10 @@ METRICS_ENABLED={{ netbox_metrics }}
 SKIP_STARTUP_SCRIPTS=True
 WEBHOOKS_ENABLED=True
 
+INITIALIZERS_ENABLED={{ netbox_init|bool }}
+
+MAX_DB_WAIT_TIME={{ netbox_max_db_wait_time }}
+
 MEDIA_ROOT=/opt/netbox/netbox/media
 
 SUPERUSER_NAME={{ netbox_superuser_name }}


### PR DESCRIPTION
This way it is possible to speedup the netbox initialization with the help of a prepare init.sql file that is part of the configuration repository.