### PR TITLE
Ansible: Use requirements.yml for collections

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,17 +4,7 @@ exclude_paths:
   - roles/docker/tasks/install-docker-Debian.yml  # We must exclude this File until we have something that can handle blocks.
   - roles/nexus/tasks/initialize.yml  # We must exclude this File until we have something that can handle blocks.
 mock_modules:
-  - ansible.posix.mount
-  - ansible.posix.synchronize
-  - ansible.posix.sysctl
-  - community.docker.docker_container_exec
-  - community.docker.docker_compose
-  - community.docker.docker_login
-  - community.docker.docker_network
-  - community.general.filesystem
-  - community.general.modprobe
   - kolla_toolbox
-  - scan_services
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,13 @@
+---
+collections:
+  - name: https://github.com/ansible-collections/community.docker.git
+    type: git
+    version: main
+
+  - name: https://github.com/ansible-collections/community.general.git
+    type: git
+    version: main
+
+  - name: https://github.com/ansible-collections/ansible.posix.git
+    type: git
+    version: main


### PR DESCRIPTION
Closes #1019
Kolla toolbox can´t be integrated at this time, because the source
does not match with ansible standards.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
