### PR TITLE
netbox: improve start of the worker service

### DIFF
--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -72,12 +72,14 @@ services:
   netbox-worker:
     <<: *netbox
     depends_on:
-      - netbox
-      - redis
+      netbox:
+        condition: service_healthy
     entrypoint: /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py
     command: rqworker
     ports: []
     healthcheck: {}
+    networks:
+      - default
 {% if netbox_traefik|bool %}
     labels: []
 {% endif %}


### PR DESCRIPTION
* fix depends_on condition for netbox-worker service to wait for netbox service to be healthy before starting
* add networks configuration for netbox-worker service to only join the default network