### PR TITLE
Add the ability for lets encrypt on a standdalone zuul

### DIFF
--- a/roles/zuul/templates/httpd.conf.j2
+++ b/roles/zuul/templates/httpd.conf.j2
@@ -380,7 +380,10 @@ SSLStaplingCache "shmcb:/usr/local/apache2/logs/ssl_stapling(32768)"
 ##
 
 <VirtualHost _default_:80>
+Alias /.well-known/acme-challenge/ /usr/local/apache2/htdocs/.well-known/acme-challenge/
 RewriteEngine On
+RewriteCond %{REQUEST_URI} /\.well\-known/acme\-challenge/
+RewriteRule (.*) /.well-known/acme-challenge/$1 [L,QSA]
 RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
@@ -405,7 +408,8 @@ SSLEngine on
 #   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
 #   require an ECC certificate which can also be configured in
 #   parallel.
-SSLCertificateFile "/usr/local/apache2/conf/server.crt"
+SSLCertificateFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem"
+SSLCertificateKeyFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem"
 
 #   TLS-SRP mutual authentication:
 #   Enable TLS-SRP and set the path to the OpenSSL SRP verifier

--- a/roles/zuul/templates/zuul.conf.j2
+++ b/roles/zuul/templates/zuul.conf.j2
@@ -10,7 +10,7 @@ password=%(ZUUL_MARIADB_PASSWORD)s
 [scheduler]
 tenant_config=/etc/zuul/main.yaml
 log_config=/etc/zuul/logging.conf
-{% for i in zuul_connections|dict2items %}
+{% for i in connections|dict2items %}
 
 [connection "{{ i['key'] }}"]
 {% for j in i['value']|dict2items %}


### PR DESCRIPTION
- update compose template to add certificates to zuul_log_server
  container
- update apache configuration to accept acme challenge

Use this as a general discussion whether this is useful in this place or not.
For SCS zuul was deployed using zuul role provided by OSISMs ansible-collection-services.
Since we didn't use all of the services we just used the zuul role that
doesn't provide letsencrypt support.

This patch is not perfect and doesn't solve the chicken-and-egg situation for initial deployment
when certbot couldn't obtain a valid certificate since the zuul_log_server container isn't running and won't run
until certificates are provided.

So many tasks left to do on this if we want to make it right.
But before we invest a lot of effort in here we should discuss if it is the right place. Maybe
we should use another proxy service in front of the zuul_log_server which itself is already a proxy?

Maybe we should switch from http-01 challenge to DNS challenge?