### PR TITLE
Letsencrypt for standalone zuul

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -12,6 +12,7 @@ zuul_logserver_fqdn: "logs.example.org"
 zuul_webserver_fqdn: "zuul.example.org"
 zuul_webserver_admin: "admin@example.org"
 zuul_zookeeper_fqdn: "zookeeper01.example.org"
+zuul_use_acme: false
 
 zuul_base_conf_dir: /opt/zuul
 zuul_component_conf_dirs:

--- a/roles/zuul/templates/docker-compose.yaml.j2
+++ b/roles/zuul/templates/docker-compose.yaml.j2
@@ -87,8 +87,7 @@ services:
     volumes:
       - "{{ zuul_component_conf_dirs.log_server }}:/usr/local/apache2/conf:ro"
       - "log_server:/usr/local/apache2/htdocs:z"
-      - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:ro"
-      - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:ro"
+      - "/etc/letsencrypt:/etc/letsencrypt:ro"
       - "/opt/zuul/log_server/.well-known/acme-challenge/:/usr/local/apache2/htdocs/.well-known/acme-challenge/:rw"
 
 volumes:

--- a/roles/zuul/templates/docker-compose.yaml.j2
+++ b/roles/zuul/templates/docker-compose.yaml.j2
@@ -3,14 +3,14 @@ services:
   mariadb:
     container_name: "{{ container_name.mariadb }}"
     image: "{{ zuul_mariadb_image }}"
-    env_file: "{{ zuul_base_conf_dir }}/mariadb.env"
+    env_file: "{{ base_conf_dir }}/mariadb.env"
   zookeeper:
     container_name: "{{ container_name.zookeeper }}"
     image: "{{ zuul_zookeeper_image }}"
-    hostname: {{ zuul_zookeeper_fqdn }}
+    hostname: {{ zookeeper_fqdn }}
     volumes:
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
-      - "{{ zuul_component_conf_dirs.zookeeper }}/zoo.cfg:/conf/zoo.cfg:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.zookeeper }}/zoo.cfg:/conf/zoo.cfg:z"
     command: zkServer.sh start-foreground
   nodepool_builder:
     container_name: "{{ container_name.nodepool_builder }}"
@@ -20,8 +20,8 @@ services:
     image: "{{ zuul_nodepool_builder_image }}"
     privileged: true
     volumes:
-      - "{{ zuul_component_conf_dirs.nodepool_builder }}:/etc/nodepool/:z"
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.nodepool_builder }}:/etc/nodepool/:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
       - "/srv/dib_cache:/srv/dib_cache:rw"
       - "/srv/dib_tmp:/srv/dib_tmp:rw"
       - "/srv/nodepool:/srv/nodepool"
@@ -34,8 +34,8 @@ services:
       - zookeeper
     image: "{{ zuul_nodepool_launcher_image }}"
     volumes:
-      - "{{ zuul_component_conf_dirs.nodepool_launcher }}:/etc/nodepool/:z"
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.nodepool_launcher }}:/etc/nodepool/:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
       - "/etc/openstack:/etc/openstack:ro"
       - "/var/log/nodepool:/var/log/nodepool:rw"
   zuul_scheduler:
@@ -43,14 +43,14 @@ services:
     depends_on:
       - zookeeper
       - mariadb
-    env_file: "{{ zuul_base_conf_dir }}/scheduler.env"
+    env_file: "{{ base_conf_dir }}/scheduler.env"
     command: "sh -c '/wait-to-start.sh && zuul-scheduler -f'"
     image: "{{ zuul_scheduler_image }}"
     volumes:
-      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ zuul_component_conf_dirs.ssh_keys }}:/var/ssh:z"
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
-      - "{{ zuul_component_conf_dirs.scheduler }}/wait-to-start.sh:/wait-to-start.sh:ro"
+      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ component_conf_dirs.ssh_keys }}:/var/ssh:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.scheduler }}/wait-to-start.sh:/wait-to-start.sh:ro"
       - "/var/log/zuul:/var/log/zuul"
   zuul_web:
     container_name: "{{ container_name.zuul_web }}"
@@ -60,22 +60,22 @@ services:
     ports:
       - "9000:9000"
     image: "{{ zuul_web_image }}"
-    env_file: "{{ zuul_base_conf_dir }}/web.env"
+    env_file: "{{ base_conf_dir }}/web.env"
     volumes:
-      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
       - "/var/log/zuul:/var/log/zuul"
   zuul_executor:
     container_name: "{{ container_name.zuul_executor }}"
     privileged: true
-    env_file: "{{ zuul_base_conf_dir }}/executor.env"
+    env_file: "{{ base_conf_dir }}/executor.env"
     depends_on:
       - zuul_scheduler
     image: "{{ zuul_executor_image }}"
     volumes:
-      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ zuul_component_conf_dirs.ssh_keys }}:/var/ssh:z"
-      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ component_conf_dirs.ssh_keys }}:/var/ssh:z"
+      - "{{ component_conf_dirs.certs }}:/var/certs:z"
       - "log_server:/srv/static/logs:z"
       - "/var/log/zuul:/var/log/zuul"
   log_server:
@@ -85,8 +85,11 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "{{ zuul_component_conf_dirs.log_server }}:/usr/local/apache2/conf:ro"
+      - "{{ component_conf_dirs.log_server }}:/usr/local/apache2/conf:ro"
       - "log_server:/usr/local/apache2/htdocs:z"
+      - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:ro"
+      - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:ro"
+      - "/opt/zuul/log_server/.well-known/acme-challenge/:/usr/local/apache2/htdocs/.well-known/acme-challenge/:rw"
 
 volumes:
   log_server:

--- a/roles/zuul/templates/docker-compose.yaml.j2
+++ b/roles/zuul/templates/docker-compose.yaml.j2
@@ -3,14 +3,14 @@ services:
   mariadb:
     container_name: "{{ container_name.mariadb }}"
     image: "{{ zuul_mariadb_image }}"
-    env_file: "{{ base_conf_dir }}/mariadb.env"
+    env_file: "{{ zuul_base_conf_dir }}/mariadb.env"
   zookeeper:
     container_name: "{{ container_name.zookeeper }}"
     image: "{{ zuul_zookeeper_image }}"
-    hostname: {{ zookeeper_fqdn }}
+    hostname: {{ zuul_zookeeper_fqdn }}
     volumes:
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
-      - "{{ component_conf_dirs.zookeeper }}/zoo.cfg:/conf/zoo.cfg:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.zookeeper }}/zoo.cfg:/conf/zoo.cfg:z"
     command: zkServer.sh start-foreground
   nodepool_builder:
     container_name: "{{ container_name.nodepool_builder }}"
@@ -20,8 +20,8 @@ services:
     image: "{{ zuul_nodepool_builder_image }}"
     privileged: true
     volumes:
-      - "{{ component_conf_dirs.nodepool_builder }}:/etc/nodepool/:z"
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.nodepool_builder }}:/etc/nodepool/:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
       - "/srv/dib_cache:/srv/dib_cache:rw"
       - "/srv/dib_tmp:/srv/dib_tmp:rw"
       - "/srv/nodepool:/srv/nodepool"
@@ -34,8 +34,8 @@ services:
       - zookeeper
     image: "{{ zuul_nodepool_launcher_image }}"
     volumes:
-      - "{{ component_conf_dirs.nodepool_launcher }}:/etc/nodepool/:z"
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.nodepool_launcher }}:/etc/nodepool/:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
       - "/etc/openstack:/etc/openstack:ro"
       - "/var/log/nodepool:/var/log/nodepool:rw"
   zuul_scheduler:
@@ -43,14 +43,14 @@ services:
     depends_on:
       - zookeeper
       - mariadb
-    env_file: "{{ base_conf_dir }}/scheduler.env"
+    env_file: "{{ zuul_base_conf_dir }}/scheduler.env"
     command: "sh -c '/wait-to-start.sh && zuul-scheduler -f'"
     image: "{{ zuul_scheduler_image }}"
     volumes:
-      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ component_conf_dirs.ssh_keys }}:/var/ssh:z"
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
-      - "{{ component_conf_dirs.scheduler }}/wait-to-start.sh:/wait-to-start.sh:ro"
+      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ zuul_component_conf_dirs.ssh_keys }}:/var/ssh:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.scheduler }}/wait-to-start.sh:/wait-to-start.sh:ro"
       - "/var/log/zuul:/var/log/zuul"
   zuul_web:
     container_name: "{{ container_name.zuul_web }}"
@@ -60,22 +60,22 @@ services:
     ports:
       - "9000:9000"
     image: "{{ zuul_web_image }}"
-    env_file: "{{ base_conf_dir }}/web.env"
+    env_file: "{{ zuul_base_conf_dir }}/web.env"
     volumes:
-      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
       - "/var/log/zuul:/var/log/zuul"
   zuul_executor:
     container_name: "{{ container_name.zuul_executor }}"
     privileged: true
-    env_file: "{{ base_conf_dir }}/executor.env"
+    env_file: "{{ zuul_base_conf_dir }}/executor.env"
     depends_on:
       - zuul_scheduler
     image: "{{ zuul_executor_image }}"
     volumes:
-      - "{{ component_conf_dirs.zuul }}:/etc/zuul/:z"
-      - "{{ component_conf_dirs.ssh_keys }}:/var/ssh:z"
-      - "{{ component_conf_dirs.certs }}:/var/certs:z"
+      - "{{ zuul_component_conf_dirs.zuul }}:/etc/zuul/:z"
+      - "{{ zuul_component_conf_dirs.ssh_keys }}:/var/ssh:z"
+      - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
       - "log_server:/srv/static/logs:z"
       - "/var/log/zuul:/var/log/zuul"
   log_server:
@@ -85,7 +85,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "{{ component_conf_dirs.log_server }}:/usr/local/apache2/conf:ro"
+      - "{{ zuul_component_conf_dirs.log_server }}:/usr/local/apache2/conf:ro"
       - "log_server:/usr/local/apache2/htdocs:z"
       - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem:ro"
       - "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem:ro"

--- a/roles/zuul/templates/httpd.conf.j2
+++ b/roles/zuul/templates/httpd.conf.j2
@@ -408,8 +408,13 @@ SSLEngine on
 #   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
 #   require an ECC certificate which can also be configured in
 #   parallel.
+
+{% if zuul_use_acme %}
 SSLCertificateFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem"
 SSLCertificateKeyFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem"
+{% else %}
+SSLCertificateFile "/usr/local/apache2/conf/server.crt"
+{% endif %}
 
 #   TLS-SRP mutual authentication:
 #   Enable TLS-SRP and set the path to the OpenSSL SRP verifier

--- a/roles/zuul/templates/httpd.conf.j2
+++ b/roles/zuul/templates/httpd.conf.j2
@@ -380,7 +380,10 @@ SSLStaplingCache "shmcb:/usr/local/apache2/logs/ssl_stapling(32768)"
 ##
 
 <VirtualHost _default_:80>
+Alias /.well-known/acme-challenge/ /usr/local/apache2/htdocs/.well-known/acme-challenge/
 RewriteEngine On
+RewriteCond %{REQUEST_URI} /\.well\-known/acme\-challenge/
+RewriteRule (.*) /.well-known/acme-challenge/$1 [L,QSA]
 RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>
 
@@ -405,7 +408,8 @@ SSLEngine on
 #   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
 #   require an ECC certificate which can also be configured in
 #   parallel.
-SSLCertificateFile "/usr/local/apache2/conf/server.crt"
+SSLCertificateFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/fullchain.pem"
+SSLCertificateKeyFile "/etc/letsencrypt/live/{{ zuul_logserver_fqdn }}/privkey.pem"
 
 #   TLS-SRP mutual authentication:
 #   Enable TLS-SRP and set the path to the OpenSSL SRP verifier

--- a/roles/zuul/templates/zuul.conf.j2
+++ b/roles/zuul/templates/zuul.conf.j2
@@ -10,7 +10,7 @@ password=%(ZUUL_MARIADB_PASSWORD)s
 [scheduler]
 tenant_config=/etc/zuul/main.yaml
 log_config=/etc/zuul/logging.conf
-{% for i in connections|dict2items %}
+{% for i in zuul_connections|dict2items %}
 
 [connection "{{ i['key'] }}"]
 {% for j in i['value']|dict2items %}

--- a/roles/zuul/templates/zuul.conf.j2
+++ b/roles/zuul/templates/zuul.conf.j2
@@ -10,7 +10,7 @@ password=%(ZUUL_MARIADB_PASSWORD)s
 [scheduler]
 tenant_config=/etc/zuul/main.yaml
 log_config=/etc/zuul/logging.conf
-{% for i in zuul_connections|dict2items %}
+{% for i in connections|dict2items %}
 
 [connection "{{ i['key'] }}"]
 {% for j in i['value']|dict2items %}


### PR DESCRIPTION
* update compose template to add certificates to zuul_log_server
    container
* update apache configuration to accept acme challenge

Use this as a general discussion whether this is useful in this place or not.
For SCS zuul was deployed using zuul role provided by OSISMs ansible-collection-services.
Since we didn't use all of the services we just used the zuul role that
doesn't provide letsencrypt support.

This patch is not perfect and doesn't solve the chicken-and-egg situation for initial deployment
when certbot couldn't obtain a valid certificate since the zuul_log_server container isn't running and won't run
until certificates are provided.

So many tasks left to do on this if we want to make it right.
But before we invest a lot of effort in here we should discuss if it is the right place. Maybe
we should use another proxy service in front of the zuul_log_server which itself is already a proxy?

Maybe we should switch from http-01 challenge to DNS challenge?
