### PR TITLE
squid: Add .debian.org to allowed targets

### DIFF
--- a/roles/squid/defaults/main.yml
+++ b/roles/squid/defaults/main.yml
@@ -31,6 +31,7 @@ squid_container_name: squid
 squid_allowed_addresses_defaults:
   - .archive.ubuntu.com
   - .cloudfront.net
+  - .debian.org
   - .opendev.org
   - .quay.io
   - .regiocloud.tech


### PR DESCRIPTION
So Debian based servers can download packages.