### PR TITLE
thanos_sidecar: add thanos sidecar role

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following Ansible roles are included in this collection.
 | rsyslog                  | ![Test role rsyslog](https://github.com/osism/ansible-collection-services/workflows/Test%20role%20rsyslog/badge.svg)       |
 | scaphandre               |                                                                                                                            |
 | smartd                   | ![Test role smartd](https://github.com/osism/ansible-collection-services/workflows/Test%20role%20smartd/badge.svg)         |
+| thanos_sidecar           |                                                                                                                            |
 | traefik                  |                                                                                                                            |
 | tuned                    | ![Test role tuned](https://github.com/osism/ansible-collection-services/workflows/Test%20role%20tuned/badge.svg)           |
 | virtualbmc               |                                                                                                                            |

--- a/roles/thanos_sidecar/README.rst
+++ b/roles/thanos_sidecar/README.rst
@@ -24,7 +24,7 @@ Group from the user which will own the configuration directory.
 Set this to the MTU for your outside connection.
 
 .. zuul:rolevar:: docker_registry_thanos_sidecar
-   :default: quay.io/thanos
+   :default: quay.io
 
 The registry for the Thanos sidecar container image.
 
@@ -88,6 +88,6 @@ Port where Thanos sidecar HTTP endpoint will be reachable from outside.
 Version from the Thanos sidecar which should be installed.
 
 .. zuul:rolevar:: thanos_sidecar_image
-   :default: {{ docker_registry_thanos_sidecar }}/thanos:{{ thanos_sidecar_tag }}
+   :default: {{ docker_registry_thanos_sidecar }}/thanos/thanos:{{ thanos_sidecar_tag }}
 
 The container image to use.

--- a/roles/thanos_sidecar/README.rst
+++ b/roles/thanos_sidecar/README.rst
@@ -1,0 +1,93 @@
+Ansible role for the deployment of the Thanos sidecar.
+
+Thanos sidecar is a component that gets deployed along with a Prometheus instance and
+allow Thanos queriers to query Prometheus data.
+
+**Operator Variables**
+
+.. zuul:rolevar:: operator_user
+   :default: dragon
+
+The user which will own the configuration directory.
+
+.. zuul:rolevar:: operator_group
+   :default: operator_user
+
+Group from the user which will own the configuration directory.
+
+
+**Docker Variables**
+
+.. zuul:rolevar:: docker_network_mtu
+   :default: 1500
+
+Set this to the MTU for your outside connection.
+
+.. zuul:rolevar:: docker_registry_thanos_sidecar
+   :default: quay.io/thanos
+
+The registry for the Thanos sidecar container image.
+
+
+**Thanos sidecar Variables**
+
+.. zuul:rolevar:: thanos_sidecar_container_name
+   :default: thanos_sidecar
+
+Name of the container in which Thanos sidecar will run.
+
+.. zuul:rolevar:: thanos_sidecar_configuration_directory
+   :default: /opt/thanos_sidecar/configuration
+
+In this directory the configuration files for Thanos sidecar will be stored.
+
+.. zuul:rolevar:: thanos_sidecar_docker_compose_directory
+   :default: /opt/thanos_sidecar
+
+Path to the directory where the Docker Compose file from Thanos sidecar will
+be stored.
+
+.. zuul:rolevar:: thanos_sidecar_network
+   :default: 172.31.101.192/28
+
+The network to use for the Thanos sidecar container.
+
+.. zuul:rolevar:: thanos_sidecar_service_name
+   :default: docker-compose@thanos_sidecar
+
+Name from the Thanos sidecar service to deal with it.
+
+.. zuul:rolevar:: thanos_sidecar_prometheus_url
+   :default: http://localhost:9090
+
+The URL where Thanos sidecar will reach Prometheus's API.
+
+.. zuul:rolevar:: thanos_sidecar_prometheus_http_client_config
+   :default: {}
+
+The Prometheus client configuration.
+
+.. zuul:rolevar:: thanos_sidecar_host
+   :default: 127.0.0.1
+
+The host where Thanos sidecar will be reachable.
+
+.. zuul:rolevar:: thanos_sidecar_grpc_port
+   :default: 10901
+
+Port where Thanos sidecar gRPC endpoint will be reachable from outside.
+
+.. zuul:rolevar:: thanos_sidecar_http_port
+   :default: 10902
+
+Port where Thanos sidecar HTTP endpoint will be reachable from outside.
+
+.. zuul:rolevar:: thanos_sidecar_tag
+   :default: v0.32.5
+
+Version from the Thanos sidecar which should be installed.
+
+.. zuul:rolevar:: thanos_sidecar_image
+   :default: {{ docker_registry_thanos_sidecar }}/thanos:{{ thanos_sidecar_tag }}
+
+The container image to use.

--- a/roles/thanos_sidecar/defaults/main.yml
+++ b/roles/thanos_sidecar/defaults/main.yml
@@ -1,0 +1,41 @@
+---
+##########################
+# operator
+
+operator_user: mato
+operator_group: "{{ operator_user }}"
+
+##########################
+# docker
+
+docker_network_mtu: 1500
+
+docker_registry_thanos_sidecar: quay.io/thanos
+
+##########################
+# thanos_sidecar
+
+thanos_sidecar_container_name: thanos_sidecar
+
+thanos_sidecar_configuration_directory: /opt/thanos_sidecar/configuration
+thanos_sidecar_docker_compose_directory: /opt/thanos_sidecar
+
+thanos_sidecar_network: 172.31.101.192/28
+thanos_sidecar_service_name: "docker-compose@thanos_sidecar"
+
+thanos_sidecar_prometheus_url: http://localhost:9090
+thanos_sidecar_prometheus_http_client_config: {}
+thanos_sidecar_host: 127.0.0.1
+thanos_sidecar_grpc_port: 10901
+thanos_sidecar_http_port: 10902
+
+thanos_sidecar_tag: 'v0.32.5'
+thanos_sidecar_image: "{{ docker_registry_thanos_sidecar }}/thanos:{{ thanos_sidecar_tag }}"
+
+##########################
+# traefik
+
+thanos_sidecar_traefik: false
+
+traefik_external_network_name: traefik
+traefik_external_network_cidr: 172.31.254.0/24

--- a/roles/thanos_sidecar/defaults/main.yml
+++ b/roles/thanos_sidecar/defaults/main.yml
@@ -10,7 +10,7 @@ operator_group: "{{ operator_user }}"
 
 docker_network_mtu: 1500
 
-docker_registry_thanos_sidecar: quay.io/thanos
+docker_registry_thanos_sidecar: quay.io
 
 ##########################
 # thanos_sidecar
@@ -29,13 +29,6 @@ thanos_sidecar_host: 127.0.0.1
 thanos_sidecar_grpc_port: 10901
 thanos_sidecar_http_port: 10902
 
+# renovate: datasource=docker depName=quay.io/thanos/thanos
 thanos_sidecar_tag: 'v0.32.5'
-thanos_sidecar_image: "{{ docker_registry_thanos_sidecar }}/thanos:{{ thanos_sidecar_tag }}"
-
-##########################
-# traefik
-
-thanos_sidecar_traefik: false
-
-traefik_external_network_name: traefik
-traefik_external_network_cidr: 172.31.254.0/24
+thanos_sidecar_image: "{{ docker_registry_thanos_sidecar }}/thanos/thanos:{{ thanos_sidecar_tag }}"

--- a/roles/thanos_sidecar/handlers/main.yml
+++ b/roles/thanos_sidecar/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart thanos_sidecar service
+  become: true
+  ansible.builtin.service:
+    name: "{{ thanos_sidecar_service_name }}"
+    state: restarted

--- a/roles/thanos_sidecar/meta/main.yml
+++ b/roles/thanos_sidecar/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Matej Feder
+  description: Role osism.services.thanos_sidecar
+  company: OSISM GmbH
+  license: Apache License 2.0
+  min_ansible_version: 2.13.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+  galaxy_tags:
+    - osism
+    - system
+dependencies: []

--- a/roles/thanos_sidecar/meta/main.yml
+++ b/roles/thanos_sidecar/meta/main.yml
@@ -2,9 +2,9 @@
 galaxy_info:
   author: Matej Feder
   description: Role osism.services.thanos_sidecar
-  company: OSISM GmbH
+  company: dNation s.r.o.
   license: Apache License 2.0
-  min_ansible_version: 2.13.0
+  min_ansible_version: 2.15.0
   platforms:
     - name: Ubuntu
       versions:

--- a/roles/thanos_sidecar/tasks/config.yml
+++ b/roles/thanos_sidecar/tasks/config.yml
@@ -1,0 +1,12 @@
+---
+- name: Create required directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0750
+  loop:
+    - "{{ thanos_sidecar_docker_compose_directory }}"
+    - "{{ thanos_sidecar_configuration_directory }}"

--- a/roles/thanos_sidecar/tasks/main.yml
+++ b/roles/thanos_sidecar/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Include config tasks
+  ansible.builtin.include_tasks: config.yml
+  tags: config
+
+- name: Include service tasks
+  ansible.builtin.include_tasks: service.yml
+  tags: service

--- a/roles/thanos_sidecar/tasks/service.yml
+++ b/roles/thanos_sidecar/tasks/service.yml
@@ -1,0 +1,16 @@
+---
+- name: Copy docker-compose.yml file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ thanos_sidecar_docker_compose_directory }}/docker-compose.yml"
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0640
+  notify: Restart thanos_sidecar service
+
+- name: Start/enable thanos_sidecar service
+  become: true
+  ansible.builtin.service:
+    name: "{{ thanos_sidecar_service_name }}"
+    state: started
+    enabled: true

--- a/roles/thanos_sidecar/templates/docker-compose.yml.j2
+++ b/roles/thanos_sidecar/templates/docker-compose.yml.j2
@@ -1,0 +1,27 @@
+---
+services:
+  thanos_sidecar:
+    image: "{{ thanos_sidecar_image }}"
+    container_name: "{{ thanos_sidecar_container_name }}"
+    restart: unless-stopped
+    command:
+      - "sidecar"
+      - "--prometheus.url={{ thanos_sidecar_prometheus_url }}"
+      - "--prometheus.http-client={{ thanos_sidecar_prometheus_http_client_config }}"
+      - "--grpc-address=0.0.0.0:10901"
+      - "--http-address=0.0.0.0:10902"
+    ports:
+      - "{{ thanos_sidecar_host }}:{{ thanos_sidecar_grpc_port }}:10901"
+      - "{{ thanos_sidecar_host }}:{{ thanos_sidecar_http_port }}:10902"
+    volumes:
+      - "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro"
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet:  {{ thanos_sidecar_network }}


### PR DESCRIPTION
This PR adds Thanos sidecar role.

Note:
- The current version does not implement the option where Thanos sidecar could write collected Prometheus metrics to the object storage. 
- The current version does not implement grpc communication  over TLS
- This version allows some (external) Thanos queriers to query testbed metrics via Thanos sidecar. 

related to https://github.com/SovereignCloudStack/issues/issues/481
