### PR TITLE
wireguard: use no_log for "Copy client configuration files"

### DIFF
--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -61,6 +61,7 @@
     group: "{{ item.name }}"
     mode: 0600
   loop: "{{ wireguard_users }}"
+  no_log: true
 
 - name: Start and enable wg-quick@wg0.service service
   become: true


### PR DESCRIPTION
This way the preshared key will not be logged.