### PR TITLE
docker: force cache update

### DIFF
--- a/roles/docker/README.rst
+++ b/roles/docker/README.rst
@@ -2,11 +2,6 @@ Ansible role for installation and configuration of Docker and all required compo
 
 **Role Variables**
 
-.. zuul:rolevar:: apt_cache_valid_time
-   :default: 3600
-
-Update the apt cache if it is older than the cache_valid_time.
-
 .. zuul:rolevar:: docker_debug
    :default: false
 

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-apt_cache_valid_time: 3600
-
 ##########################
 # generic
 

--- a/roles/docker/tasks/install-docker-Debian.yml
+++ b/roles/docker/tasks/install-docker-Debian.yml
@@ -49,12 +49,10 @@
   when: docker_configure_repository|bool
   register: result_add_repository
 
-# NOTE: make sure that the package cache is up to date so that newer Docker versions will be available in any case
-- name: Update package cache  # noqa: no-handler
+- name: Force update package cache  # noqa: no-handler
   become: true
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: "{{ apt_cache_valid_time }}"
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
   when: result_add_repository.changed
 


### PR DESCRIPTION
This is necessary so that the cache is always updated when the repository is added.