### PR TITLE
docker: ensure that some packages are not installed

### DIFF
--- a/roles/docker/tasks/install-docker-Debian.yml
+++ b/roles/docker/tasks/install-docker-Debian.yml
@@ -180,3 +180,11 @@
   when:
     - docker_registry_username is defined and docker_registry_username|string|length > 0
     - docker_registry_password is defined and docker_registry_password|string|length > 0
+
+- name: Ensure that some packages are not installed
+  become: true
+  ansible.builtin.apt:
+    name:
+      - docker-buildx-plugin
+      - docker-ce-rootless-extras
+    state: absent


### PR DESCRIPTION
Over time, the dependencies in the Docker repository have changed. It should therefore be ensured that packages from the past no longer remain installed.