### PR TITLE
Add Statsd configuration options for Zuul

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -64,6 +64,9 @@ zuul_tenants:
           untrusted-projects:
             - tibeerorg/zuul_demo_repo
 
+zuul_metrics_statsd_host: ""
+zuul_metrics_statsd_port: "8125"
+zuul_metrics_statsd_prefix: ""
 
 ###############################################################################
 # docker

--- a/roles/zuul/tasks/template_tasks.yml
+++ b/roles/zuul/tasks/template_tasks.yml
@@ -68,6 +68,8 @@
     - mariadb
     - scheduler
     - web
+    - nodepool_builder
+    - nodepool_launcher
 
 - name: Template docker-compose.yaml
   ansible.builtin.template:

--- a/roles/zuul/templates/docker-compose.yaml.j2
+++ b/roles/zuul/templates/docker-compose.yaml.j2
@@ -24,6 +24,7 @@ services:
     command: "/usr/local/bin/nodepool-builder -f -l /etc/nodepool/logging.conf"
     depends_on:
       - zookeeper
+    env_file: "{{ zuul_base_conf_dir }}/nodepool_builder.env"
     image: "{{ zuul_nodepool_builder_image }}"
     privileged: true
     volumes:
@@ -40,6 +41,7 @@ services:
     command: "/usr/local/bin/nodepool-launcher -f -l /etc/nodepool/logging.conf"
     depends_on:
       - zookeeper
+    env_file: "{{ zuul_base_conf_dir }}/nodepool_launcher.env"
     image: "{{ zuul_nodepool_launcher_image }}"
     volumes:
       - "{{ zuul_component_conf_dirs.nodepool_launcher }}:/etc/nodepool/:z"

--- a/roles/zuul/templates/env/nodepool_builder.env.j2
+++ b/roles/zuul/templates/env/nodepool_builder.env.j2
@@ -1,0 +1,4 @@
+{% if zuul_metrics_statsd_host | length > 0 %}
+STATSD_HOST={{ zuul_metrics_statsd_host }}
+STATSD_PORT={{ zuul_metrics_statsd_port }}
+{% endif %}

--- a/roles/zuul/templates/env/nodepool_launcher.env.j2
+++ b/roles/zuul/templates/env/nodepool_launcher.env.j2
@@ -1,0 +1,4 @@
+{% if zuul_metrics_statsd_host | length > 0 %}
+STATSD_HOST={{ zuul_metrics_statsd_host }}
+STATSD_PORT={{ zuul_metrics_statsd_port }}
+{% endif %}

--- a/roles/zuul/templates/zuul.conf.j2
+++ b/roles/zuul/templates/zuul.conf.j2
@@ -42,3 +42,10 @@ client_id={{ zuul_webserver_fqdn }}
 issuer_id=zuul_operator
 secret={{ zuul_auth_secret }}
 {% endif %}
+{% if zuul_metrics_statsd_host | length > 0 %}
+
+[statsd]
+server={{ zuul_metrics_statsd_host }}
+port={{ zuul_metrics_statsd_port }}
+{% if zuul_metrics_statsd_prefix | length > 0 %}prefix={{ zuul_metrics_statsd_prefix }}{% endif %}
+{% endif %}


### PR DESCRIPTION
This PR enables the configuration of Zuul Scheduler and Zuul Nodepool builder and launcher to emit metrics to the statsd receiver.

For configuring the Zuul Scheduler, the zuul.conf file should be adjusted, see https://zuul-ci.org/docs/zuul/latest/configuration.html#attr-statsd.

For the configuration of the Zuul Nodepool launcher and builder, the environment variables should be set, see https://zuul-ci.org/docs/nodepool/latest/installation.html#statsd-configuration.