### PR TITLE
Add metrics configuration option for Zookeeper

### DIFF
--- a/roles/zuul/defaults/main.yml
+++ b/roles/zuul/defaults/main.yml
@@ -68,6 +68,9 @@ zuul_metrics_statsd_host: ""
 zuul_metrics_statsd_port: "8125"
 zuul_metrics_statsd_prefix: ""
 
+zuul_zookeeper_metrics: false
+zuul_zookeeper_metrics_port: 7000
+
 ###############################################################################
 # docker
 ###############################################################################

--- a/roles/zuul/templates/docker-compose.yaml.j2
+++ b/roles/zuul/templates/docker-compose.yaml.j2
@@ -14,6 +14,10 @@ services:
     container_name: "{{ container_name.zookeeper }}"
     image: "{{ zuul_zookeeper_image }}"
     hostname: {{ zuul_zookeeper_fqdn }}
+{% if zuul_zookeeper_metrics | bool %}
+    ports:
+      - "{{ zuul_zookeeper_metrics_port }}:{{ zuul_zookeeper_metrics_port }}"
+{% endif %}
     volumes:
       - "{{ zuul_component_conf_dirs.certs }}:/var/certs:z"
       - "{{ zuul_component_conf_dirs.zookeeper }}/zoo.cfg:/conf/zoo.cfg:z"

--- a/roles/zuul/templates/zoo.cfg.j2
+++ b/roles/zuul/templates/zoo.cfg.j2
@@ -13,3 +13,7 @@ serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 secureClientPort=2281
 ssl.keyStore.location=/var/certs/keystores/{{ zuul_zookeeper_fqdn }}.pem
 ssl.trustStore.location=/var/certs/certs/cacert.pem
+{% if zuul_zookeeper_metrics | bool %}
+metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
+metricsProvider.httpPort={{ zuul_zookeeper_metrics_port }}
+{% endif %}


### PR DESCRIPTION
This PR enables the configuration of Zuul's Zookeeper component to expose metrics on the specified port.
see https://zookeeper.apache.org/doc/current/zookeeperMonitor.html