### PR TITLE
Add tasks to remove old architecture-dependent repository

### DIFF
--- a/molecule/delegated/vars/openstackclient.yml
+++ b/molecule/delegated/vars/openstackclient.yml
@@ -1,3 +1,7 @@
 ---
 operator_user: zuul
 operator_group: zuul
+
+# testing
+openstackclient_install_type: package
+openstackclient_version: bobcat

--- a/molecule/delegated/vars/openstackclient.yml
+++ b/molecule/delegated/vars/openstackclient.yml
@@ -1,7 +1,3 @@
 ---
 operator_user: zuul
 operator_group: zuul
-
-# testing
-openstackclient_install_type: package
-openstackclient_version: bobcat

--- a/roles/cephclient/tasks/package-Debian.yml
+++ b/roles/cephclient/tasks/package-Debian.yml
@@ -1,4 +1,11 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://download.ceph.com/debian-{{ cephclient_version }} {{ ansible_distribution_release }} main"
+    state: absent
+  when: cephclient_configure_repository|bool
+
 - name: Add repository key with apt-key
   become: true
   ansible.builtin.apt_key:

--- a/roles/containerd/tasks/install-Debian.yml
+++ b/roles/containerd/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: absent
+    filename: docker
+  when: docker_configure_repository|bool
+
 - name: Gather the apt package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/roles/docker/tasks/install-docker-Debian.yml
+++ b/roles/docker/tasks/install-docker-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: absent
+    filename: docker
+  when: docker_configure_repository|bool
+
 - name: Gather the apt package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/roles/falco/tasks/install-Debian.yml
+++ b/roles/falco/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://download.falco.org/packages/deb stable main"
+    state: absent
+    filename: falco
+  when: falco_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:

--- a/roles/netdata/tasks/install-Debian.yml
+++ b/roles/netdata/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://packagecloud.io/netdata/netdata-edge/ubuntu/ {{ ansible_distribution_release }} main"
+    state: absent
+    filename: netdata
+  when: netdata_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:

--- a/roles/openstackclient/tasks/package-Debian.yml
+++ b/roles/openstackclient/tasks/package-Debian.yml
@@ -1,4 +1,11 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] http://ubuntu-cloud.archive.canonical.com/ubuntu {{ ansible_distribution_release }}-updates/{{ openstackclient_version }} main"
+    state: absent
+  when: openstackclient_configure_repository|bool
+
 - name: Add repository key with apt-key
   become: true
   ansible.builtin.apt_key:

--- a/roles/osquery/tasks/install-Debian.yml
+++ b/roles/osquery/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://pkg.osquery.io/deb deb main"
+    state: absent
+    filename: osquery
+  when: osquery_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
cf. https://github.com/osism/issues/issues/849

Add task to remove old repository entry in following roles (cf. https://github.com/osism/ansible-collection-services/pull/1270): 
- [x] cephclient
- [x] openstackclient
- [x] netdata
- [x] docker
- [x] containerd
- [x] osquery
- [x] falco¹

¹ **Note:** New capabilities in [falcoctl](https://falco.org/blog/falco-0-37-0/#new-falcoctl-capabilities) to download and build kernel drivers, replacing the old falco-driver-loader script. **Needs to be fixed!** Issue opened: https://github.com/osism/issues/issues/850