### PR TITLE
keycloak: create namespace

### DIFF
--- a/roles/keycloak/tasks/create-database.yml
+++ b/roles/keycloak/tasks/create-database.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Create namespace {{ keycloak_namespace }}"
+  kubernetes.core.k8s:
+    name: "{{ keycloak_namespace }}"
+    kind: Namespace
+    state: present
+    kubeconfig: /share/kubeconfig
+
 - name: Deploy keycloak database on CloudNativePG cluster
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
The namespace has to be created before the "Deploy keycloak database on CloudNativePG cluster" task.