### PR TITLE
cloudnative_pg: wait for webhook

### DIFF
--- a/roles/cloudnative_pg/tasks/main.yml
+++ b/roles/cloudnative_pg/tasks/main.yml
@@ -5,3 +5,4 @@
     chart_ref: cnpg/cloudnative-pg
     release_namespace: cnpg-system
     create_namespace: true
+    wait: true


### PR DESCRIPTION
This will avoid the following issue when running the keycloak role after the cloudnative_pg role.

no endpoints available for service "cnpg-webhook-service"