### PR TITLE
Revert "docker: use version 26.0.2 (#1369)"

### DIFF
--- a/roles/docker/vars/Debian-family.yml
+++ b/roles/docker/vars/Debian-family.yml
@@ -6,6 +6,6 @@
 # NOTE: This "5:" must be prepended starting with version 18.09.
 #       Check available version under Ubuntu with apt-cache madison docker-ce.
 # renovate: datasource=docker depName=docker
-docker_version: '5:26.0.2'
+docker_version: '5:24.0.9'
 # renovate: datasource=docker depName=docker
-docker_cli_version: '5:26.0.2'
+docker_cli_version: '5:24.0.9'

--- a/roles/docker/vars/RedHat-family.yml
+++ b/roles/docker/vars/RedHat-family.yml
@@ -6,6 +6,6 @@
 # In CentOS, docker and docker-cli are using a different epoch
 
 # renovate: datasource=docker depName=docker
-docker_version: '3:26.0.2'
+docker_version: '3:24.0.9'
 # renovate: datasource=docker depName=docker
-docker_cli_version: '1:26.0.2'
+docker_cli_version: '1:24.0.9'


### PR DESCRIPTION
Revert this until we have a better approach to set the docker version on the manager node.

This reverts commit 17e834a8e6ceb1a8482d795e7e652e1a7cc9126a.