### PR TITLE
docker: use version 26.0.2 (pt. 2)

### DIFF
--- a/roles/docker/vars/Debian-family.yml
+++ b/roles/docker/vars/Debian-family.yml
@@ -6,6 +6,6 @@
 # NOTE: This "5:" must be prepended starting with version 18.09.
 #       Check available version under Ubuntu with apt-cache madison docker-ce.
 # renovate: datasource=docker depName=docker
-docker_version: '5:24.0.9'
+docker_version: '5:26.0.2'
 # renovate: datasource=docker depName=docker
-docker_cli_version: '5:24.0.9'
+docker_cli_version: '5:26.0.2'

--- a/roles/docker/vars/RedHat-family.yml
+++ b/roles/docker/vars/RedHat-family.yml
@@ -6,6 +6,6 @@
 # In CentOS, docker and docker-cli are using a different epoch
 
 # renovate: datasource=docker depName=docker
-docker_version: '3:24.0.9'
+docker_version: '3:26.0.2'
 # renovate: datasource=docker depName=docker
-docker_cli_version: '1:24.0.9'
+docker_cli_version: '1:26.0.2'


### PR DESCRIPTION
After the changes in osism/cfg-generics it is now possible to use pinned versions of Docker + all Ansible collections that are required to upgrade the manager service. This means that we can now upgrade the Docker version to 26.0.2.

This reverts commit 9e860541c5728773b5e3ce02d8b57266a64299df.