### PR TITLE
manager: remove become from handlers where not required

### DIFF
--- a/roles/manager/handlers/main.yml
+++ b/roles/manager/handlers/main.yml
@@ -28,13 +28,11 @@
   changed_when: true
   notify:
     - Wait for an healthy manager service
-  become: true
 
 # NOTE: The command returns a list of IDs of containers from the service
 #       that are currently starting or unhealthy. As long as the list is not empty
 #       the service is not in a good state.
 - name: Wait for an healthy manager service
-  become: true
   ansible.builtin.shell: |
     set -o pipefail
     docker compose --project-directory /opt/manager \


### PR DESCRIPTION
More privileges are not required for the handlers
that uses docker-compose commands.