### PR TITLE
zuul: install docker with pip for the manager role

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -212,6 +212,7 @@
       ansible_role: manager
     files:
       - '^roles\/manager\/.*$'
+      - '^molecule\/delegated\/prepare\/manager.*$'
       - '^molecule\/delegated\/tests\/manager.*$'
       - '^molecule\/delegated\/vars\/manager.*$'
 

--- a/molecule/delegated/prepare/manager.yml
+++ b/molecule/delegated/prepare/manager.yml
@@ -22,3 +22,8 @@
   ansible.builtin.pip:
     name: packaging
     virtualenv: /home/zuul/venv
+
+- name: Install library docker with pip
+  ansible.builtin.pip:
+    name: docker
+    virtualenv: /home/zuul/venv


### PR DESCRIPTION
Since we are working within a venv, but the python-3docker package is installed via apt, it must be installed manually in the venv so that the facts of osism.services.docker work.