### PR TITLE
Remove some more become from handlers where not required

### DIFF
--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -49,7 +49,6 @@
         state: stopped
 
     - name: Do a manual start of the manager service
-      become: true
       ansible.builtin.command: "/usr/bin/docker compose --project-directory {{ manager_docker_compose_directory }} up -d --remove-orphans"
       changed_when: true
       notify:

--- a/roles/openstackclient/handlers/main.yml
+++ b/roles/openstackclient/handlers/main.yml
@@ -8,7 +8,6 @@
     - Ensure that all containers are up
 
 - name: Ensure that all containers are up
-  become: true
   ansible.builtin.command:
     cmd: docker compose --project-directory /opt/openstackclient up -d
   changed_when: true
@@ -19,7 +18,6 @@
 #       that are currently starting or unhealthy. As long as the list is not empty
 #       the service is not in a good state.
 - name: Wait for an healthy service
-  become: true
   ansible.builtin.shell: |
     set -o pipefail
     docker compose --project-directory /opt/openstackclient \


### PR DESCRIPTION
More privileges are not required for the handlers
using docker-compose commands.

Related to 14d51ce2b0c751c45f69356950020a88605a7c58