### PR TITLE
rsyslog: use prefix variables for OS specific defaults

### DIFF
--- a/molecule/delegated/tests/rsyslog.py
+++ b/molecule/delegated/tests/rsyslog.py
@@ -36,7 +36,7 @@ def test_rsyslog_configuration_files(host):
             rsyslog_conf_file.mode == 0o644
         ), "rsyslog.conf should have 0644 permissions"
 
-        rsyslog_user = get_dist_role_variable(host, "rsyslog_user")
+        rsyslog_user = get_dist_role_variable(host, "__rsyslog_user")
         rsyslog_file_owner = "$FileOwner {}".format(rsyslog_user)
 
         assert "MODULES" in rsyslog_conf_file.content_string

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Gather variables for each operating system
   ansible.builtin.include_vars: "{{ ansible_distribution }}-dist.yml"
 
+- name: Set rsyslog_user variable to default value
+  ansible.builtin.set_fact:
+    rsyslog_user: "{{ __rsyslog_user }}"
+  when: rsyslog_user|default(None) == None
+
 - name: Include distribution specific install tasks
   ansible.builtin.include_tasks: "install-{{ ansible_os_family }}-family.yml"
 

--- a/roles/rsyslog/vars/CentOS-dist.yml
+++ b/roles/rsyslog/vars/CentOS-dist.yml
@@ -1,2 +1,2 @@
 ---
-rsyslog_user: root
+__rsyslog_user: root

--- a/roles/rsyslog/vars/Debian-dist.yml
+++ b/roles/rsyslog/vars/Debian-dist.yml
@@ -1,2 +1,2 @@
 ---
-rsyslog_user: root
+__rsyslog_user: root

--- a/roles/rsyslog/vars/Ubuntu-dist.yml
+++ b/roles/rsyslog/vars/Ubuntu-dist.yml
@@ -1,2 +1,2 @@
 ---
-rsyslog_user: syslog
+__rsyslog_user: syslog


### PR DESCRIPTION
Part of osism/issues#1000