### PR TITLE
chrony: use prefix variables for OS specific defaults

### DIFF
--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -2,6 +2,16 @@
 - name: Gather variables for each operating system
   ansible.builtin.include_vars: "{{ ansible_os_family }}-family.yml"
 
+- name: Set chrony_conf_file variable to default value
+  ansible.builtin.set_fact:
+    chrony_conf_file: "{{ __chrony_conf_file }}"
+  when: chrony_conf_file|default(None) == None
+
+- name: Set chrony_key_file variable to default value
+  ansible.builtin.set_fact:
+    chrony_key_file: "{{ __chrony_key_file }}"
+  when: chrony_key_file|default(None) == None
+
 - name: Populate service facts
   ansible.builtin.service_facts:
 

--- a/roles/chrony/vars/Debian-family.yml
+++ b/roles/chrony/vars/Debian-family.yml
@@ -1,4 +1,4 @@
 ---
-chrony_conf_file: /etc/chrony/chrony.conf
-chrony_key_file: /etc/chrony/chrony.keys
+__chrony_conf_file: /etc/chrony/chrony.conf
+__chrony_key_file: /etc/chrony/chrony.keys
 chrony_service_name: chrony

--- a/roles/chrony/vars/RedHat-family.yml
+++ b/roles/chrony/vars/RedHat-family.yml
@@ -1,4 +1,4 @@
 ---
-chrony_conf_file: /etc/chrony.conf
-chrony_key_file: /etc/chrony.keys
+__chrony_conf_file: /etc/chrony.conf
+__chrony_key_file: /etc/chrony.keys
 chrony_service_name: chronyd


### PR DESCRIPTION
Part of osism/issues#1000