### PR TITLE
traefik: allow extra ports

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -28,6 +28,7 @@ traefik_port: 8122
 
 traefik_port_http: 80
 traefik_port_https: 443
+traefik_ports_extra: []
 
 # traefik_certificates:
 #   dashboard:

--- a/roles/traefik/templates/docker-compose.yml.j2
+++ b/roles/traefik/templates/docker-compose.yml.j2
@@ -8,6 +8,9 @@ services:
       - "{{ traefik_host }}:{{ traefik_port }}:8080"
       - "{{ traefik_host }}:{{ traefik_port_https }}:443"
       - "{{ traefik_host }}:{{ traefik_port_http }}:80"
+{% for port in traefik_ports_extra %}
+      - "{{ traefik_host }}:{{ port }}:{{ port }}"
+{% endfor %}
     env_file:
       - "{{ traefik_configuration_directory }}/traefik.env"
     volumes:

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -20,6 +20,11 @@ entryPoints:
   https:
     address: ":443"
 
+{% for port in traefik_ports_extra %}
+  port_{{ port }}:
+    address: ":{{ port }}"
+{% endfor %}
+
 ping: {}
 
 {% if traefik_configuration_extra.keys() | length %}


### PR DESCRIPTION
With traefik_extra_ports it's possible to manage
additional ports with traefik.

E.g. to manage port 5000 and port 8774:

traefik_extra_ports:
  - 5000
  - 8774