### PR TITLE
traefik: allow dynamic service configuration

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -37,6 +37,7 @@ traefik_ports_extra: []
 traefik_certificates: {}
 
 traefik_configuration_extra: {}
+traefik_configuration_dynamic: {}
 
 # renovate: datasource=docker depName=traefik
 traefik_tag: '2.11.2'

--- a/roles/traefik/tasks/config.yml
+++ b/roles/traefik/tasks/config.yml
@@ -44,3 +44,20 @@
     group: "{{ operator_group }}"
   loop: "{{ traefik_certificates | dict2items }}"
   no_log: true
+
+- name: Copy dynamic configuration
+  ansible.builtin.template:
+    src: dynamic.yml.j2
+    dest: "{{ traefik_configuration_directory }}/dynamic.yml"
+    mode: 0644
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+  notify: Restart traefik service
+  when: traefik_configuration_dynamic.keys() | length
+
+- name: Remove dynamic configuration
+  ansible.builtin.file:
+    path: "{{ traefik_configuration_directory }}/dynamic.yml"
+    state: absent
+  notify: Restart traefik service
+  when: not traefik_configuration_dynamic.keys() | length

--- a/roles/traefik/templates/docker-compose.yml.j2
+++ b/roles/traefik/templates/docker-compose.yml.j2
@@ -17,7 +17,10 @@ services:
       - "/etc/hosts:/etc/hosts:ro"
       - "{{ traefik_configuration_directory }}/traefik.yml:/etc/traefik/traefik.yml:ro"
       - "{{ traefik_configuration_directory }}/certificates.yml:/etc/traefik/dynamic/certificates.yml:ro"
-{% if traefik_certificates.keys() | length >0 %}
+{% if traefik_configuration_dynamic.keys() | length > 0 %}
+      - "{{ traefik_configuration_directory }}/dynamic.yml:/etc/traefik/dynamic/dynamic.yml:ro"
+{% endif %}
+{% if traefik_certificates.keys() | length > 0 %}
       - "{{ traefik_certificates_directory }}:/etc/traefik/certificates:ro"
 {% endif %}
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/roles/traefik/templates/dynamic.yml.j2
+++ b/roles/traefik/templates/dynamic.yml.j2
@@ -1,0 +1,2 @@
+---
+{{ traefik_configuration_dynamic | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
With the traefik_configuration_dynamic parameter it's possible to define additional services via the file provider.

This will add a router that routes all requests on api-81-163-192-117.traefik.me to the service-horizon service.

traefik_configuration_dyanmic:
  tcp:
    services:
      service-horizon:
        loadBalancer:
          servers:
            - address: "192.168.16.254:443" routers: router-horizon: rule: "HostSNI(`api-81-163-192-117.traefik.me`)" service: service-horizon