### PR TITLE
docker: allow to throttle docker service restarts

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -14,6 +14,7 @@ docker_group: "{{ operator_group | default('dragon') }}"
 docker_allow_restart: true
 docker_enforce_restart: false
 docker_ignore_restart_groupname: manager
+docker_throttle_restart: -1
 
 ##########################
 # networking

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.systemd:
     state: restarted
     name: "{{ docker_service_name }}"
+  throttle: "{{ docker_throttle_restart }}"
   when: (docker_allow_restart|bool and inventory_hostname not in groups[docker_ignore_restart_groupname] | default([])) or
         (docker_allow_restart|bool and inventory_hostname in groups[docker_ignore_restart_groupname] | default([]) and docker_enforce_restart|bool)
 


### PR DESCRIPTION
With the docker_throttle_restart parameter it's possible to throttle the service restarts. By default service restarts will not be throttled.

Part of osism/issues#813