### PR TITLE
docker: allow to wait some time after docker serivce restart

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -16,6 +16,9 @@ docker_enforce_restart: false
 docker_ignore_restart_groupname: manager
 docker_throttle_restart: -1
 
+docker_wait_after_restart: false
+docker_wait_after_restart_seconds: 60
+
 ##########################
 # networking
 

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -7,6 +7,12 @@
   throttle: "{{ docker_throttle_restart }}"
   when: (docker_allow_restart|bool and inventory_hostname not in groups[docker_ignore_restart_groupname] | default([])) or
         (docker_allow_restart|bool and inventory_hostname in groups[docker_ignore_restart_groupname] | default([]) and docker_enforce_restart|bool)
+  notify: Wait after docker service restart
+
+- name: Wait after docker service restart
+  ansible.builtin.pause:
+    seconds: "{{ docker_wait_after_restart_seconds }}"
+  when: docker_wait_after_restart | bool
 
 - name: Reload docker service
   become: true


### PR DESCRIPTION
Can be enabled with the docker_wait_after_restart parameter. Disabled by default.

The seconds to wait can be set with the
docker_wait_after_restart_seconds parameter. The default value is 60.