### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/add-molecule-testinfra-a7d15bed7af6bd86.yaml
+++ b/releasenotes/notes/add-molecule-testinfra-a7d15bed7af6bd86.yaml
@@ -1,4 +1,0 @@
----
-other:
-  - |
-    Added unittests for Molecule delegated scenario with testinfra (molecule/delegated/tests)

--- a/releasenotes/notes/add-molecule-zuul-job-e07b844fc1022e36.yaml
+++ b/releasenotes/notes/add-molecule-zuul-job-e07b844fc1022e36.yaml
@@ -1,7 +1,0 @@
----
-other:
-  - |
-    After adding Ansible Molecule job to osim/zuul-jobs repository (#50)
-    GitHub Workflows for test roles are no longer required and has been
-    removed (.github/workflows/test-role-*). For each test role a job was
-    created in .zuul.yaml.

--- a/releasenotes/notes/homer-remove-kibana-d0c81feafe1af25e.yaml
+++ b/releasenotes/notes/homer-remove-kibana-d0c81feafe1af25e.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Parameter `homer_kibana_url` has been removed from role homer.
-    The parameter `homer_opensearch_dashboards_url` can now be used.

--- a/releasenotes/notes/manager-ara-server-mariadb-volume-type-cb20abe7946ecbed.yaml
+++ b/releasenotes/notes/manager-ara-server-mariadb-volume-type-cb20abe7946ecbed.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    With the parameter `ara_server_mariadb_volume_type` in the manager role
-    it is now possible to use a tmpfs volume for the mariadb service used by
-    the ARA service. This is intended for use in the CI to speed up processes
-    there.

--- a/releasenotes/notes/manager-ara-server-new-parameters-4dde69d8d501ebc4.yaml
+++ b/releasenotes/notes/manager-ara-server-new-parameters-4dde69d8d501ebc4.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    New parameters have been added to the manager role for the ara-server service.
-    With `ara_threads` the number of used threads can be configured. With
-    `ara_worker_connections` the number of worker connections can be configured.
-    The default of `ara_worker_class` changed to gevent.

--- a/releasenotes/notes/manager-ara_server_mariadb_healthcheck-71e116352e2cf62b.yaml
+++ b/releasenotes/notes/manager-ara_server_mariadb_healthcheck-71e116352e2cf62b.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    The healthcheck of the mariadb service used by the ARA service
-    is now set via `ara_server_mariadb_healthcheck` dependent on the
-    version of the mariadb image.

--- a/releasenotes/notes/manager-fs.inotify.max_user_instances-2a71c3ac11e8da69.yaml
+++ b/releasenotes/notes/manager-fs.inotify.max_user_instances-2a71c3ac11e8da69.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Set `fs.inotify.max_user_instances = 256` on the manager to fix the
-    `Failed to allocate directory watch: Too many open files` issue.

--- a/releasenotes/notes/manager-improve-wait-for-an-healthy-manager-services-fc6132d1cfeed397.yaml
+++ b/releasenotes/notes/manager-improve-wait-for-an-healthy-manager-services-fc6132d1cfeed397.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    The `Wait for an healthy manager service` task in the manager role
-    now also waits for containers in state `created`.

--- a/releasenotes/notes/manager-listener-enable-8be154e1398e0ff9.yaml
+++ b/releasenotes/notes/manager-listener-enable-8be154e1398e0ff9.yaml
@@ -1,8 +1,0 @@
----
-features:
-  - |
-    The listener service of the manager is now disabled by default.
-upgrade:
-  - |
-    Set `enable_listener: true` in `environments/manager/configuration.yml` to
-    enable the listener service of the manager.

--- a/releasenotes/notes/manager-mariadb-MARIADB_AUTO_UPGRADE-7b3812dd9a8dd91c.yaml
+++ b/releasenotes/notes/manager-mariadb-MARIADB_AUTO_UPGRADE-7b3812dd9a8dd91c.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Setting `MARIADB_AUTO_UPGRADE=1` as an environment variable for the mariadb
-    container of the manager service will auto-upgrade running mariadb-upgrade
-    inside the mariadb container.

--- a/releasenotes/notes/manager-more-healthchecks-2819198e29a80405.yaml
+++ b/releasenotes/notes/manager-more-healthchecks-2819198e29a80405.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Add health checks for the manager services listener, openstack,
-    and watchdog. Add health checks for the manager workers netbox
-    and conductor.

--- a/releasenotes/notes/manager-only-copy-bash-completion-with-celery-integration-b50dadda5e9b897f.yaml
+++ b/releasenotes/notes/manager-only-copy-bash-completion-with-celery-integration-b50dadda5e9b897f.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Copy the bash completion script from the osismclient container only if the Celery
-    integration is enabled.

--- a/releasenotes/notes/manager-opensearch-protocol-6899e3ff20ec511b.yaml
+++ b/releasenotes/notes/manager-opensearch-protocol-6899e3ff20ec511b.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    With the `manager_opensearch_protocol` parameter it is now possible
-    to configure the protocol (`http` or `https`) that should be used by
-    `osism log opensearch`.

--- a/releasenotes/notes/manager-osism-update-docker-b519e7ad5bbeabcb.yaml
+++ b/releasenotes/notes/manager-osism-update-docker-b519e7ad5bbeabcb.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `osism-update-docker` script, also available via `osism update docker`,
-    it is possible to update the Docker service on the manager.

--- a/releasenotes/notes/manager-remove-osism-mirror-e621c82c1d666cbf.yaml
+++ b/releasenotes/notes/manager-remove-osism-mirror-e621c82c1d666cbf.yaml
@@ -1,6 +1,0 @@
----
-other:
-  - |
-    In `osism.services.manager` the `osism-mirror` script has been removed.
-    The script no longer worked and new scripts are now available in the
-    `osism/sbom` repository to mirror container images.

--- a/releasenotes/notes/manager-resource-limits-8dc65134a0738a8d.yaml
+++ b/releasenotes/notes/manager-resource-limits-8dc65134a0738a8d.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    In osism.services.manager it is now possible to limit the used resources of
-    Ansible services via the arguments `manager_mem_limit`, `manager_mem_reservation`,
-    and `manager_cpus`.

--- a/releasenotes/notes/manager-sources-configurable-98bb9a9b6fdc68c9.yaml
+++ b/releasenotes/notes/manager-sources-configurable-98bb9a9b6fdc68c9.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Git sources in the `osism update manager` script are now configurable via
-    the environment variables `ANSIBLE_COLLECTION_SERVICES_SOURCE` and
-    `ANSIBLE_PLAYBOOKS_MANAGER_SOURCE`.

--- a/releasenotes/notes/manager-update-wrapper-arguments-2f5ea72ac68aa8ec.yaml
+++ b/releasenotes/notes/manager-update-wrapper-arguments-2f5ea72ac68aa8ec.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Allow use of arguments in the osism update commands.

--- a/releasenotes/notes/mariadb-use-healthcheck.sh-script-85633547115b539c.yaml
+++ b/releasenotes/notes/mariadb-use-healthcheck.sh-script-85633547115b539c.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    Use new `healthcheck.sh` script for the healthcheck of the MariaDB
-    service of the manager as mysqladmin is not longer usable. Further
-    details at
-    https://mariadb.org/mariadb-server-docker-official-images-healthcheck-without-mysqladmin/

--- a/releasenotes/notes/netbox-add-healthcheck-3dbaa2f0fca8c19d.yaml
+++ b/releasenotes/notes/netbox-add-healthcheck-3dbaa2f0fca8c19d.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add health check to the netbox worker service.

--- a/releasenotes/notes/netbox-netbox_postgres_volume_typ-ade52938ba4a2185.yaml
+++ b/releasenotes/notes/netbox-netbox_postgres_volume_typ-ade52938ba4a2185.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    With the parameter `netbox_postgres_volume_type` in the netbox role
-    it is now possible to use a tmpfs volume for the postgres service
-    This is intended for use in the CI to speed up processes there.

--- a/releasenotes/notes/remove-patchman-686a14202925b24b.yaml
+++ b/releasenotes/notes/remove-patchman-686a14202925b24b.yaml
@@ -1,5 +1,0 @@
----
-upgrade:
-  - |
-    The Patchman roles were deprecated with OSISM 6.0.0 and have now been removed.
-    The Patchman service is no longer usable in OSISM.

--- a/releasenotes/notes/squid-add-healthcheck-6adfb0f696672c2b.yaml
+++ b/releasenotes/notes/squid-add-healthcheck-6adfb0f696672c2b.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add health check to the squid container.

--- a/releasenotes/notes/squid-remove-whitelist-42419d9868936912.yaml
+++ b/releasenotes/notes/squid-remove-whitelist-42419d9868936912.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    The internal Squid service is no longer used for filtering. Access to all external sources
-    is possible. The existing whitelist no longer made sense because, for example, access to
-    Quay or Docker Hub was completely permitted and any artifacts could then be downloaded anyway.
-    If you want to filter at this level in the future, you will need an additional proxy or WAF.

--- a/releasenotes/notes/squid-version-5.7-23.04_beta-e05f0f4d729abf6b.yaml
+++ b/releasenotes/notes/squid-version-5.7-23.04_beta-e05f0f4d729abf6b.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    In the squid role, tag `5.7-23.04_beta` is now used for image
-    `ubuntu/squid` by default.

--- a/releasenotes/notes/traefik-add-healthcheck-5c0f41f233cb60d0.yaml
+++ b/releasenotes/notes/traefik-add-healthcheck-5c0f41f233cb60d0.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Enable /ping endpoint of traefik and add health check to the
-    traefik container.

--- a/releasenotes/notes/wait-for-healthy-containers-aa18406aa766d3a7.yaml
+++ b/releasenotes/notes/wait-for-healthy-containers-aa18406aa766d3a7.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Wait for healthy openstackclient and cephclient containers before copying
-    the bash completion script.

--- a/releasenotes/notes/zuul-volume-settings-dfdcc32a900018cb.yaml
+++ b/releasenotes/notes/zuul-volume-settings-dfdcc32a900018cb.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    zuul: Add parameters `zuul_log_volume` and `zuul_mariadb_volume`
-    in order to make volumes for the log and mariadb containers
-    configurable.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.