### PR TITLE
docker: add docker_python_install parameter

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -71,6 +71,8 @@ docker_packages_fail:
 ##########################
 # python package
 
+docker_python_install: true
+
 docker_python3_package_name: python3-docker
 docker_python_package_name: python-docker
 docker_python_package_names:

--- a/roles/docker/tasks/install-docker-Debian-family.yml
+++ b/roles/docker/tasks/install-docker-Debian-family.yml
@@ -131,7 +131,9 @@
         state: present
         lock_timeout: "{{ apt_lock_timeout | default(300) }}"
 
-  when: not docker_python_install_from_pip|bool
+  when:
+    - docker_python_install | bool
+    - not docker_python_install_from_pip | bool
 
 - name: Install python bindings with pip  # noqa: key-order[task], osism-fqcn
   become: true
@@ -166,7 +168,9 @@
         executable: pip3
         state: present
 
-  when: docker_python_install_from_pip|bool
+  when:
+    - docker_python_install | bool
+    - docker_python_install_from_pip | bool
 
 - name: Install packages required by docker login
   become: true

--- a/roles/docker/tasks/install-docker-RedHat-family.yml
+++ b/roles/docker/tasks/install-docker-RedHat-family.yml
@@ -86,7 +86,9 @@
     name: "{{ docker_python3_package_name }}"
     state: present
     lock_timeout: "{{ lock_timeout | default(300) }}"
-  when: not docker_python_install_from_pip|bool
+  when:
+    - docker_python_install | bool
+    - not docker_python_install_from_pip | bool
 
 - name: Install python bindings with pip  # noqa: key-order[task], osism-fqcn
   become: true
@@ -110,7 +112,9 @@
         executable: pip3
         state: present
 
-  when: docker_python_install_from_pip|bool
+  when:
+    - docker_python_install | bool
+    - docker_python_install_from_pip | bool
 
 - name: Install packages required by docker login
   become: true


### PR DESCRIPTION
With the boolean docker_python_install parameter it is possible to enable and disable the installation of the Python docker bindings.