### PR TITLE
molecule: also check on ubuntu 24.04

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -144,6 +144,28 @@
       - '^roles\/fail2ban\/.*$'
       - '^molecule\/delegated\/tests\/fail2ban.*$'
 
+# The fail2ban service is currently broken on Ubuntu 24.04.
+# The issue is already fixed, but it has not yet arrived in the repositories.
+# https://bugs.launchpad.net/ubuntu/+source/fail2ban/+bug/2055114
+- job:
+    name: ansible-collection-services-molecule-fail2ban
+    parent: abstract-ansible-collection-services-molecule
+    nodeset:
+      nodes:
+        - name: centos-9-stream
+          label: centos-9-stream
+        - name: debian-bookworm
+          label: debian-bookworm
+        - name: ubuntu-jammy
+          label: ubuntu-jammy
+    vars:
+      ansible_role: fail2ban
+    files:
+      - '^roles\/fail2ban\/.*$'
+      - '^molecule\/delegated\/prepare\/fail2ban.*$'
+      - '^molecule\/delegated\/tests\/fail2ban.*$'
+      - '^molecule\/delegated\/vars\/fail2ban.*$'
+
 - job:
     name: ansible-collection-services-molecule-falco
     parent: abstract-ansible-collection-services-molecule

--- a/molecule/delegated/tests/fail2ban.py
+++ b/molecule/delegated/tests/fail2ban.py
@@ -1,28 +1,16 @@
-import pytest
 from .util.util import get_ansible, get_variable
 
 testinfra_runner, testinfra_hosts = get_ansible()
 
 
-def test_srv(host):
-    """
-    Temporary skipping on Ubuntu 24.04 as the service is currently unstable on 24.04
-    Also see: https://bugs.launchpad.net/ubuntu/+source/fail2ban/+bug/2055114
-    """
-
-    if (
-        get_variable(host, "ansible_distribution", True) == "Ubuntu"
-        and get_variable(host, "ansible_distribution_version", True) == "24.04"
-    ):
-        pytest.skip("Skipping this test on Ubuntu 24.04")
-
+def test_fail2ban_service(host):
     service = host.service(get_variable(host, "fail2ban_service_name"))
 
     assert service.is_running
     assert service.is_enabled
 
 
-def test_pkg(host):
+def test_fail2ban_package(host):
     package_name = get_variable(host, "fail2ban_package_name")
     assert package_name != ""
 


### PR DESCRIPTION
It makes no sense to skip a unit test on a specific distro version. Either we have to skip the whole molecule test for Ubuntu 24.04 or the failed test is ok until upstream fixed the LP#2055114.