### PR TITLE
manager: add manager_enable_openstack parameter

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -282,6 +282,11 @@ enable_listener: false
 manager_listener_broker_uri: "amqp://openstack:password@127.0.0.1:5672/"
 
 ##########################
+# openstack
+
+manager_enable_openstack: true
+
+##########################
 # service integrations
 
 manager_enable_ironic: true

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -194,6 +194,7 @@ services:
 {% endif %}
 {% endif %}
 
+{% if manager_enable_openstack|bool %}
   ##########################################
   # openstack integration service
 
@@ -215,6 +216,7 @@ services:
       - "{{ manager_configuration_directory }}/openstack.env"
 {% if enable_netbox|bool %}
       - "{{ manager_configuration_directory }}/netbox.env"
+{% endif %}
 {% endif %}
 
   ##########################################


### PR DESCRIPTION
With the manager_enable_openstack parameter it is possible to disable the openstack integration. This is useful for clusters without OpenStack. The default value of the manager_enable_openstack parameter is true.