### PR TITLE
Add option for host networking instead of container networking

### DIFF
--- a/roles/cephclient/defaults/main.yml
+++ b/roles/cephclient/defaults/main.yml
@@ -35,6 +35,7 @@ cephclient_image: "{{ docker_registry_cephclient }}/osism/cephclient:{{ cephclie
 cephclient_container_name: cephclient
 
 cephclient_network: 172.31.100.0/28
+cephclient_host_networking: false
 
 cephclient_service_name: "docker-compose@cephclient"
 

--- a/roles/cephclient/templates/docker-compose.yml.j2
+++ b/roles/cephclient/templates/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     image: "{{ cephclient_image }}"
     command: sleep infinity
-{% if cephclient_host_networking %}
+{% if cephclient_host_networking | bool %}
     network_mode: host
 {% endif %}
     volumes:
@@ -13,7 +13,7 @@ services:
       - "{{ cephclient_data_directory }}:/data:rw"
       - "/etc/hosts:/etc/hosts:ro"
 
-{% if not cephclient_host_networking %}
+{% if not cephclient_host_networking | bool %}
 networks:
   default:
     driver: bridge

--- a/roles/cephclient/templates/docker-compose.yml.j2
+++ b/roles/cephclient/templates/docker-compose.yml.j2
@@ -5,11 +5,15 @@ services:
     restart: unless-stopped
     image: "{{ cephclient_image }}"
     command: sleep infinity
+{% if cephclient_host_networking %}
+    network_mode: host
+{% endif %}
     volumes:
       - "{{ cephclient_configuration_directory }}:/etc/ceph:rw"
       - "{{ cephclient_data_directory }}:/data:rw"
       - "/etc/hosts:/etc/hosts:ro"
 
+{% if not cephclient_host_networking %}
 networks:
   default:
     driver: bridge
@@ -19,3 +23,4 @@ networks:
       driver: default
       config:
         - subnet:  {{ cephclient_network }}
+{% endif %}

--- a/roles/openstackclient/defaults/main.yml
+++ b/roles/openstackclient/defaults/main.yml
@@ -31,6 +31,7 @@ openstackclient_image: "{{ docker_registry_openstackclient }}/osism/openstackcli
 openstackclient_container_name: openstackclient
 
 openstackclient_network: 172.31.100.16/28
+openstackclient_host_networking: false
 
 openstackclient_service_name: "docker-compose@openstackclient"
 
@@ -40,7 +41,6 @@ openstackclient_service_name: "docker-compose@openstackclient"
 openstackclient_configure_repository: true
 
 openstackclient_ubuntu_repository: "deb http://ubuntu-cloud.archive.canonical.com/ubuntu {{ ansible_distribution_release }}-updates/{{ openstackclient_version }} main"
-
 
 openstackclient_debian_packages:
   - python3-openstackclient

--- a/roles/openstackclient/templates/docker-compose.yml.j2
+++ b/roles/openstackclient/templates/docker-compose.yml.j2
@@ -5,6 +5,9 @@ services:
     restart: unless-stopped
     image: "{{ openstackclient_image }}"
     command: sleep infinity
+{% if openstackclient_host_networking %}
+    network_mode: host
+{% endif %}
     volumes:
       - "{{ openstackclient_configuration_directory }}:/configuration:ro"
       - "{{ openstackclient_data_directory }}:/data:ro"
@@ -22,7 +25,7 @@ services:
 {% endif %}
 
 
-
+{% if not openstackclient_host_networking %}
 networks:
   default:
     driver: bridge
@@ -32,3 +35,4 @@ networks:
       driver: default
       config:
         - subnet:  {{ openstackclient_network }}
+{% endif %}

--- a/roles/openstackclient/templates/docker-compose.yml.j2
+++ b/roles/openstackclient/templates/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     image: "{{ openstackclient_image }}"
     command: sleep infinity
-{% if openstackclient_host_networking %}
+{% if openstackclient_host_networking | bool %}
     network_mode: host
 {% endif %}
     volumes:
@@ -25,7 +25,7 @@ services:
 {% endif %}
 
 
-{% if not openstackclient_host_networking %}
+{% if not openstackclient_host_networking | bool %}
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
Some containers liek cephclient and openstackclient are using container networking, causing the outside of the container to be reached via NAT.

We've ran in to an issue where the NAT was done with the source-IP address of our management interface instead of the dummy interface that should be used, causing the packets to reach it's destination with the wrong source-IP.

I think this might even be a bug in Docker's networking, as it honoured the route but dismissed the 'src' flag. Quite frankly we are fine with running the containers in host networking mode, so there should be an option to do so if desired IMO.