### PR TITLE
molecule: always install requests

### DIFF
--- a/molecule/delegated/prepare.yml
+++ b/molecule/delegated/prepare.yml
@@ -10,6 +10,7 @@
       loop:
         - docker
         - netaddr
+        - requests
 
     - name: Include required prepare tasks
       ansible.builtin.include_tasks:


### PR DESCRIPTION
This is required to be able to create the external traefik network.