### PR TITLE
cephclient: remove crushtool wrapper

### DIFF
--- a/molecule/delegated/tests/cephclient/container.py
+++ b/molecule/delegated/tests/cephclient/container.py
@@ -92,7 +92,7 @@ def test_srv(host):
 def test_wrapper(host):
     check_cephclient_install_type(host)
 
-    items = ["ceph", "ceph-authtool", "crushtool", "rados", "radosgw-admin", "rbd"]
+    items = ["ceph", "ceph-authtool", "rados", "radosgw-admin", "rbd"]
 
     for item in items:
         f = host.file(f"/usr/local/bin/{item}")

--- a/roles/cephclient/tasks/container.yml
+++ b/roles/cephclient/tasks/container.yml
@@ -62,7 +62,14 @@
   loop:
     - ceph
     - ceph-authtool
-    - crushtool
     - rados
     - radosgw-admin
     - rbd
+
+- name: Remove old wrapper scripts
+  become: true
+  ansible.builtin.file:
+    path: "/usr/local/bin/{{ item }}"
+    state: absent
+  loop:
+    - crushtool


### PR DESCRIPTION
The crushtool is today only available in the ceph-base package. The ceph-base package installs a lot of requirements in the cephclient container image. Because of that we remove the crushtool wrapper. The crushtool can be used on the Ceph control nodes.