### PR TITLE
traefik: remove parameter traefik_pilot_dashboard

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -49,6 +49,4 @@ traefik_service_name: "docker-compose@traefik"
 traefik_external_network_name: traefik
 traefik_external_network_cidr: 172.31.254.0/24
 
-traefik_pilot_dashboard: false
-
 traefik_log_level: "INFO"

--- a/roles/traefik/templates/traefik.env.j2
+++ b/roles/traefik/templates/traefik.env.j2
@@ -1,1 +1,0 @@
-TRAEFIK_PILOT_DASHBOARD={{ traefik_pilot_dashboard }}


### PR DESCRIPTION
Pilot configuration has been removed in v3.