### PR TITLE
netbox: wait up to 10 minutes for netbox

### DIFF
--- a/roles/netbox/handlers/main.yml
+++ b/roles/netbox/handlers/main.yml
@@ -39,6 +39,6 @@
     executable: /bin/bash
   register: result
   until: "result.stdout | length == 0"
-  retries: 30
+  retries: 60
   delay: 10
   changed_when: true


### PR DESCRIPTION
The initial DB bootstrap can take some time on slow manager nodes.