### PR TITLE
hddtemp: Add drivetemp module check

### DIFF
--- a/molecule/delegated/tests/hddtemp/debian.py
+++ b/molecule/delegated/tests/hddtemp/debian.py
@@ -23,9 +23,6 @@ def test_pkg(host):
 def test_modulefile(host):
     check_ansible_os_family(host)
 
-    if not get_variable(host, "hddtemp_enable_module"):
-        pytest.skip("Kernel module not enabled")
-
     f = host.file("/etc/modules")
     assert f.exists
     assert not f.is_directory
@@ -35,9 +32,6 @@ def test_modulefile(host):
 
 def test_module(host):
     check_ansible_os_family(host)
-
-    if not get_variable(host, "hddtemp_enable_module"):
-        pytest.skip("Kernel module not enabled")
 
     with host.sudo():
         loaded_modules = host.check_output("lsmod").splitlines()

--- a/roles/hddtemp/defaults/main.yml
+++ b/roles/hddtemp/defaults/main.yml
@@ -1,2 +1,1 @@
 ---
-hddtemp_enable_module: true

--- a/roles/hddtemp/tasks/install-Debian-family.yml
+++ b/roles/hddtemp/tasks/install-Debian-family.yml
@@ -13,14 +13,19 @@
     dest: /etc/modules
     mode: 0644
     state: present
-  when: hddtemp_enable_module
+
+- name: Check if drivetemp module is available
+  ansible.builtin.command: find /lib/modules/{{ ansible_kernel }} -type f -name '*drivetemp*'
+  register: drivetemp_check
+  changed_when: false
+  failed_when: false
 
 - name: Load Kernel Module drivetemp
   become: true
   community.general.modprobe:
     name: drivetemp
     state: present
-  when: hddtemp_enable_module
+  when: drivetemp_check.rc == 0
 
 - name: Install lm-sensors
   become: true


### PR DESCRIPTION
Check if drivetemp module is available before loading on Debian and Ubuntu.

Reverts changes from https://github.com/osism/ansible-collection-services/pull/1467