### PR TITLE
add cleanup possible legacy cephclient wrapper installations

### DIFF
--- a/roles/cephclient/tasks/clean-container.yml
+++ b/roles/cephclient/tasks/clean-container.yml
@@ -1,0 +1,21 @@
+---
+- name: Stop cephclient service
+  become: true
+  ansible.builtin.service:
+    name: "{{ cephclient_service_name }}"
+    state: stopped
+    enabled: false
+  register: result
+  until: result.state == "stopped"
+  retries: 10
+  delay: 20
+
+- name: Remove required directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ cephclient_configuration_directory }}"
+    - "{{ cephclient_data_directory }}"
+    - "{{ cephclient_docker_compose_directory }}"

--- a/roles/cephclient/tasks/clean-package-Debian-family.yml
+++ b/roles/cephclient/tasks/clean-package-Debian-family.yml
@@ -8,13 +8,10 @@
 - name: Remove configuration files
   become: true
   ansible.builtin.file:
-    path: "/etc/ceph/ceph.conf"
-    owner: "root"
-    group: "root"
-    mode: 0644
+    path: /etc/ceph/ceph.conf
     state: absent
 
-- name: Uninstall required packages
+- name: Uninstall packages
   become: true
   ansible.builtin.apt:
     name: "{{ cephclient_packages }}"
@@ -28,12 +25,9 @@
   ansible.builtin.apt_repository:
     repo: "{{ cephclient_debian_repository }}"
     state: absent
-  when: cephclient_configure_repository | bool
 
 - name: Remove repository gpg key
   become: true
   ansible.builtin.file:
     path: /etc/apt/trusted.gpg.d/cephclient.asc
     state: absent
-  when:
-    - cephclient_configure_repository | bool

--- a/roles/cephclient/tasks/clean-package-Debian-family.yml
+++ b/roles/cephclient/tasks/clean-package-Debian-family.yml
@@ -1,0 +1,39 @@
+---
+- name: Remove keyring file
+  become: true
+  ansible.builtin.file:
+    path: "/etc/ceph/ceph.{{ cephclient_keyring_name }}.keyring"
+    state: absent
+
+- name: Remove configuration files
+  become: true
+  ansible.builtin.file:
+    path: "/etc/ceph/ceph.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+    state: absent
+
+- name: Uninstall required packages
+  become: true
+  ansible.builtin.apt:
+    name: "{{ cephclient_packages }}"
+    state: absent
+    autoclean: true
+    autoremove: true
+    clean: true
+
+- name: Remove repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "{{ cephclient_debian_repository }}"
+    state: absent
+  when: cephclient_configure_repository | bool
+
+- name: Remove repository gpg key
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/cephclient.asc
+    state: absent
+  when:
+    - cephclient_configure_repository | bool

--- a/roles/cephclient/tasks/clean-package-RedHat-family.yml
+++ b/roles/cephclient/tasks/clean-package-RedHat-family.yml
@@ -8,13 +8,10 @@
 - name: Remove configuration files
   become: true
   ansible.builtin.file:
-    path: "/etc/ceph/ceph.conf"
-    owner: "root"
-    group: "root"
-    mode: 0644
+    path: /etc/ceph/ceph.conf
     state: absent
 
-- name: Uninstall required packages
+- name: Uninstall packages
   become: true
   ansible.builtin.dnf:
     name: "{{ cephclient_packages }}"
@@ -27,4 +24,3 @@
   ansible.builtin.yum_repository:
     name: ceph
     state: absent
-  when: cephclient_configure_repository | bool

--- a/roles/cephclient/tasks/clean-package-RedHat-family.yml
+++ b/roles/cephclient/tasks/clean-package-RedHat-family.yml
@@ -1,0 +1,30 @@
+---
+- name: Remove keyring file
+  become: true
+  ansible.builtin.file:
+    path: "/etc/ceph/ceph.{{ cephclient_keyring_name }}.keyring"
+    state: absent
+
+- name: Remove configuration files
+  become: true
+  ansible.builtin.file:
+    path: "/etc/ceph/ceph.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+    state: absent
+
+- name: Uninstall required packages
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ cephclient_packages }}"
+    state: absent
+    autoremove: true
+    lock_timeout: "{{ dnf_lock_timeout | default(300) }}"
+
+- name: Remove repository
+  become: true
+  ansible.builtin.yum_repository:
+    name: ceph
+    state: absent
+  when: cephclient_configure_repository | bool

--- a/roles/cephclient/tasks/rook.yml
+++ b/roles/cephclient/tasks/rook.yml
@@ -1,4 +1,22 @@
 ---
+- name: Anything to cleanup from package install
+  ansible.builtin.stat:
+    path: "/etc/ceph/ceph.{{ cephclient_keyring_name }}.keyring"
+  register: package_result
+
+- name: Anything to cleanup from container install
+  ansible.builtin.stat:
+    path: "{{ cephclient_docker_compose_directory }}/docker-compose.yml"
+  register: container_result
+
+- name: Remove package installation {{ ansible_os_family }}
+  ansible.builtin.include_tasks: "clean-package-{{ ansible_os_family }}-family.yml"
+  when: package_result.stat.exists
+
+- name: Remove cephclient container installation
+  ansible.builtin.include_tasks: "clean-container.yml"
+  when: container_result.stat.exists
+
 - name: Copy wrapper scripts
   become: true
   ansible.builtin.template:


### PR DESCRIPTION
This was tested using a testbed deployment and a cephclient installation using `package`-method as well as `container`-method prior to change the installation method to `rook` followed by an `osism apply cephclient` again to verify the cleanup of both existing installation methods.
Implements: https://github.com/osism/issues/issues/1038