### PR TITLE
squid: Add max_filedescriptors limit to config

### DIFF
--- a/roles/squid/templates/osism.conf.j2
+++ b/roles/squid/templates/osism.conf.j2
@@ -2,6 +2,7 @@ cache_mem 128 MB
 minimum_object_size 0 bytes
 maximum_object_size 500 MB
 maximum_object_size_in_memory 512 KB
+max_filedescriptors 1048576
 
 cache_dir ufs /var/spool/squid 100 16 256
 


### PR DESCRIPTION
Squid will allocate memory for caching based on the maximum file descriptors. If not specified in the squid config, it will pull the default value from the system limits. On CentOS 9 the limit is much higher than on Debian/Ubuntu (1073741816 vs 1048576). This will lead to page faults when spinning up the container on CentOS.

This commit adds the ``max_filedescriptors`` limit to the squid config with the default value of Debian/Ubuntu preventing the crash.