### PR TITLE
netbox: add netbox_wait_for_healthy_service param

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -45,6 +45,7 @@ netbox_tag: 'v3.7.8'
 netbox_image: "{{ docker_registry_netbox }}/osism/netbox:{{ netbox_tag }}"
 
 netbox_service_restart: true
+netbox_wait_for_healthy_service: true
 
 # SECRET_KEY must be at least 50 characters in length.
 netbox_secret_key: "00000000000000000000000000000000000000000000000000"

--- a/roles/netbox/handlers/main.yml
+++ b/roles/netbox/handlers/main.yml
@@ -42,3 +42,4 @@
   retries: 60
   delay: 10
   changed_when: true
+  when: netbox_wait_for_healthy_service | bool


### PR DESCRIPTION
With the netbox_wait_for_healthy_service param it is possible to skip the "Wait for healty netbox service" handler.