### PR TITLE
FIX: Git data source sync in Netbox does not work

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -39,7 +39,7 @@ netbox_port: 8121
 netbox_osism_api_host: "{{ netbox_host }}"
 netbox_osism_api_port: 8000
 
-netbox_userid: 101
+netbox_user: 'unit:root'
 
 # renovate: datasource=docker depName=quay.io/osism/netbox
 netbox_tag: 'v4.0.8'

--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -35,7 +35,7 @@ services:
   netbox: &netbox
     image: "{{ netbox_image }}"
     restart: unless-stopped
-    user: "{{ netbox_userid }}"
+    user: "{{ netbox_user }}"
     env_file:
       - "{{ netbox_configuration_directory }}/netbox.env"
     depends_on:


### PR DESCRIPTION
Nginx Unit user UID has changed to 999 which breaks the git data source sync in Netbox.

Netbox 3.7.x container fixed this and used the user name and group `unit:root` instead of user ID.

This fix sets the default netbox user in the same way as `unit:root`.

Refer to the related issue and netbox-docker PR:
- https://github.com/netbox-community/netbox-docker/issues/1200
- https://github.com/netbox-community/netbox-docker/pull/589