### PR TITLE
Fix default SCRIPTS_ROOT path in Netbox configuration.py

### DIFF
--- a/molecule/delegated/tests/netbox.py
+++ b/molecule/delegated/tests/netbox.py
@@ -101,7 +101,7 @@ def test_netbox_config(host):
     assert config_py.user == get_variable(host, "operator_user")
     assert config_py.group == get_variable(host, "operator_group")
     assert (
-        "SCRIPTS_ROOT = os.environ.get('SCRIPTS_ROOT', '/etc/netbox/scripts')"
+        "SCRIPTS_ROOT = os.environ.get('SCRIPTS_ROOT', '/opt/netbox/netbox/scripts')"
         in config_py.content_string
     )
 

--- a/roles/netbox/templates/configuration.py.j2
+++ b/roles/netbox/templates/configuration.py.j2
@@ -3,7 +3,7 @@ import re
 import socket
 
 # For reference see https://netbox.readthedocs.io/en/stable/configuration/
-# Based on https://github.com/netbox-community/netbox/blob/develop/netbox/netbox/configuration.example.py
+# Based on https://github.com/netbox-community/netbox/blob/develop/netbox/netbox/configuration_example.py
 
 # Read secret from file
 def read_secret(secret_name):
@@ -207,7 +207,7 @@ REPORTS_ROOT = os.environ.get('REPORTS_ROOT', '/etc/netbox/reports')
 
 # The file path where custom scripts will be stored. A trailing slash is not needed. Note that the default value of
 # this setting is derived from the installed location.
-SCRIPTS_ROOT = os.environ.get('SCRIPTS_ROOT', '/etc/netbox/scripts')
+SCRIPTS_ROOT = os.environ.get('SCRIPTS_ROOT', '/opt/netbox/netbox/scripts')
 
 # Time zone (default: UTC)
 TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')


### PR DESCRIPTION
The default directory /etc/netbox/scripts does not exist in the NetBox container, therefore, the attempt to add the script failed.

This commit sets the existing directory /opt/netbox/netbox/scripts as the default.

For issue replication:
- Add a new data source to the Netbox (navigate to Operations/Data sources) and sync it.
-  Try to add a script from added data source in Netbox (navigate to Customization/Scripts)