### PR TITLE
metering: Fix container spawn race condition

### DIFF
--- a/molecule/delegated/tests/metering.py
+++ b/molecule/delegated/tests/metering.py
@@ -1,4 +1,4 @@
-from .util.util import get_ansible, get_variable
+from .util.util import get_ansible, get_variable, assert_service_running_and_enabled
 
 testinfra_runner, testinfra_hosts = get_ansible()
 
@@ -44,7 +44,6 @@ def test_metering_container_running(host):
 
 
 def test_metering_service_running(host):
-    metering_service_name = get_variable(host, "metering_service_name")
-    service = host.service(metering_service_name)
-    assert service.is_enabled
-    assert service.is_running
+    assert_service_running_and_enabled(
+        host, get_variable(host, "metering_service_name")
+    )

--- a/molecule/delegated/tests/util/util.py
+++ b/molecule/delegated/tests/util/util.py
@@ -1,4 +1,5 @@
 import os
+import time
 import urllib.request
 import testinfra.utils.ansible_runner
 
@@ -103,6 +104,16 @@ def get_centos_repo_key(host, summary):
     installed_key = "\n".join(installed_key.split("\n")[2:])
 
     return installed_key
+
+
+def assert_service_running_and_enabled(host, service_name):
+    time.sleep(5)
+
+    service = host.service(service_name)
+    assert service.is_enabled
+
+    debug = host.run(f"systemctl status {service_name}")
+    assert service.is_running, debug
 
 
 def jinja_replacement(original_variable, replacements):

--- a/roles/metering/tasks/main.yml
+++ b/roles/metering/tasks/main.yml
@@ -38,5 +38,4 @@
   become: true
   ansible.builtin.service:
     name: "{{ metering_service_name }}"
-    state: started
     enabled: true


### PR DESCRIPTION
The container is restarted from the tasks changing the docker-compose yaml files. The additional ``state: started`` in the manage task was racing the handler restart, sometimes spawning multiple containers with the same name.

This also adds a five second delay to the pytest which checks if the container is running