### PR TITLE
share pids with host

### DIFF
--- a/roles/scaphandre/defaults/main.yml
+++ b/roles/scaphandre/defaults/main.yml
@@ -26,6 +26,8 @@ scaphandre_service_name: "docker-compose@scaphandre"
 scaphandre_host: 127.0.0.1
 scaphandre_port: 9155
 
+scaphandre_share_pids_with_host: true
+
 scaphandre_exporter: prometheus
 scaphandre_flags_defaults:
   - "--qemu"

--- a/roles/scaphandre/templates/docker-compose.yml.j2
+++ b/roles/scaphandre/templates/docker-compose.yml.j2
@@ -3,6 +3,9 @@ services:
   scaphandre:
     image: "{{ scaphandre_image }}"
     container_name: "{{ scaphandre_container_name }}"
+{% if scaphandre_share_pids_with_host %}
+    pid: host
+{% endif %}
     restart: unless-stopped
     entrypoint: scaphandre {{ scaphandre_exporter }} {{ scaphandre_flags|join(" ") }}
     ports:


### PR DESCRIPTION
Scaphandre is only capable to fetch detailed information about process execution for processes which have access to the global pid namespace.

This enables the parameter "pid: host" for the docker compose file. (https://docs.docker.com/reference/cli/docker/container/run/#pid)