### PR TITLE
frr: allow to use frr_uplinks__* parameters in host vars

### DIFF
--- a/roles/frr/defaults/main.yml
+++ b/roles/frr/defaults/main.yml
@@ -20,8 +20,11 @@ frr_sysctl_defaults:
 frr_sysctl_extra: []
 frr_sysctl: "{{ frr_sysctl_defaults + frr_sysctl_extra }}"
 
-frr_dummy_interface: dummy0
 frr_uplinks: []
+frr_uplinks_groups:
+  - generic
+
+frr_dummy_interface: dummy0
 frr_local_as: 4200000000
 frr_type: leaf
 frr_loopback_v4: 127.0.0.42

--- a/roles/frr/tasks/main.yml
+++ b/roles/frr/tasks/main.yml
@@ -12,7 +12,11 @@
     mode: 0640
   notify: Restart frr service
 
-- name: Install frr.conf configuration file
+- name: Set _frr_uplinks fact
+  ansible.builtin.set_fact:
+    _frr_uplinks: "{{ lookup('community.general.merge_variables', '^frr_uplinks__.+$', initial_value=frr_uplinks, groups=frr_uplinks_groups) }}"
+
+- name: Copy frr.conf configuration file
   become: true
   ansible.builtin.template:
     src: "frr_{{ frr_type }}.conf.j2"

--- a/roles/frr/templates/frr_k3s_cilium.conf.j2
+++ b/roles/frr/templates/frr_k3s_cilium.conf.j2
@@ -8,14 +8,14 @@ router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp router-id {{ frr_loopback_v4 }}
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
  neighbor {{ item.address }} remote-as {{ item.remote_as }}
  neighbor {{ item.address }} update-source {{ item.interface }}
  neighbor {{ item.address }} soft-reconfiguration inbound
 {% endfor %}
  !
  address-family ipv4 unicast
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
   neighbor {{ item.address }} next-hop
 {% endfor %}
  exit-address-family

--- a/roles/frr/templates/frr_leaf.conf.j2
+++ b/roles/frr/templates/frr_leaf.conf.j2
@@ -8,13 +8,13 @@ router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp router-id {{ frr_loopback_v4 }}
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
  neighbor {{ item.interface }} interface remote-as {{ item.remote_as }}
 {% endfor %}
  !
  address-family ipv4 unicast
   redistribute connected route-map bgp_out
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
   neighbor {{ item.interface }} route-map bgp_out out
 {% endfor %}
   maximum-paths 2
@@ -22,7 +22,7 @@ router bgp {{ frr_local_as }}
  !
  address-family ipv6 unicast
   redistribute connected route-map bgp_out
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
   neighbor {{ item.interface }} activate
   neighbor {{ item.interface }} route-map bgp_out out
 {% endfor %}

--- a/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
@@ -8,13 +8,13 @@ router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp router-id {{ frr_loopback_v4 }}
-{% for item in frr_uplinks + frr_uplinks_external %}
+{% for item in _frr_uplinks + frr_uplinks_external %}
  neighbor {{ item.interface }} interface remote-as {{ item.remote_as }}
 {% endfor %}
  !
  address-family ipv4 unicast
   redistribute connected
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
   neighbor {{ item.interface }} route-map bgp_out_internal out
 {% endfor %}
 {% for item in frr_uplinks_external %}
@@ -26,7 +26,7 @@ router bgp {{ frr_local_as }}
  !
  address-family ipv6 unicast
   redistribute connected
-{% for item in frr_uplinks %}
+{% for item in _frr_uplinks %}
   neighbor {{ item.interface }} activate
   neighbor {{ item.interface }} route-map bgp_out_internal out
 {% endfor %}


### PR DESCRIPTION
All frr_uplinks__* parameters will be merged with the frr_uplinks parameter. This way it is possible to add host specific frr_uplinks via the host vars.