### PR TITLE
docker: add docker_storage_containerd_snapshotter parameter

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -97,14 +97,13 @@ docker_registry_mirrors: []
 ##########################
 # storage driver
 
-# NOTE: overlay2 is the default choice for Docker CE
 docker_storage_driver: overlay2
+docker_storage_containerd_snapshotter: "false"
 
 ##########################
 # storage block device
 
 docker_configure_storage_block_device: false
-
 docker_storage_block_device: /dev/sdb
 docker_storage_filesystem: ext4
 docker_storage_force: false

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -58,6 +58,12 @@
     },
 {% endif %}
     "registry-mirrors": [{% for mirror in docker_registry_mirrors %}"{{ mirror }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+{% if docker_storage_containerd_snapshotter == 'true' %}
+    "features": {
+      "containerd-snapshotter": {{ docker_storage_containerd_snapshotter }}
+    },
+{% else %}
     "storage-driver": "{{ docker_storage_driver }}",
+{% endif %}
     "default-runtime": "{{ docker_default_runtime }}"
 }


### PR DESCRIPTION
With the docker_storage_containerd_snapshotter parameter it is possible to enable the experimental container-snapshotter feature.

https://docs.docker.com/engine/storage/containerd/