### PR TITLE
Revert "manager: make openstack env available in the osismclient"

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -284,7 +284,6 @@ services:
     env_file:
       - "{{ manager_configuration_directory }}/ansible.env"
       - "{{ manager_configuration_directory }}/client.env"
-      - "{{ manager_configuration_directory }}/openstack.env"
 {% if enable_netbox|bool %}
       - "{{ manager_configuration_directory }}/netbox.env"
 {% endif %}


### PR DESCRIPTION
This reverts commit c4052116ac22afb27be65667ec58eb78204b47fb.

We'll use the cloud profiles instead of the environment variables.