### PR TITLE
nexus: add nexus_force_init parameter

### DIFF
--- a/roles/nexus/defaults/main.yml
+++ b/roles/nexus/defaults/main.yml
@@ -32,12 +32,14 @@ nexus_container_name: nexus
 nexus_old_service_name: "docker-compose@nexus"
 nexus_service_name: "nexus"
 
-# NOTE: provision scripts that are included in the Nexus container image
+nexus_force_init: false
+
+# provision scripts that are included in the Nexus container image
 nexus_provision_scripts:
   - anonymous.json
   - cleanup.json
 
-# NOTE: provision scripts that are included in this role
+# provision scripts that are included in this role
 nexus_provision_groovy_scripts:
   - create_repos_from_list
   - setup_http_proxy

--- a/roles/nexus/tasks/main.yml
+++ b/roles/nexus/tasks/main.yml
@@ -10,4 +10,6 @@
 - name: Include initialize tasks
   ansible.builtin.include_tasks: initialize.yml
   tags: initialize
-  when: not ansible_local.osism.nexus.status | default("False") | bool
+  when:
+    - (not ansible_local.osism.nexus.status | default("False") | bool or
+       nexus_force_init | bool)


### PR DESCRIPTION
With the nexus_force_init parameter it is possible to force the initialisation of the service.