### PR TITLE
Fix rendering of netbox plugins configuration

### DIFF
--- a/roles/netbox/templates/configuration.py.j2
+++ b/roles/netbox/templates/configuration.py.j2
@@ -29,7 +29,7 @@ PLUGINS_CONFIG = {
 {% for k2, v2 in v.items() %}
         '{{ k2 }}': '{{ v2 }}',
 {% endfor %}
-    }
+    },
 {% endfor %}
 }
 


### PR DESCRIPTION
In the case of multiple Netbox plugin configuration items, e.g.:
```yaml
netbox_plugins_config:
  netbox_config_diff:
    USERNAME: "admin"
    PASSWORD: "YourPaSsWoRd"
  netbox_topology_views:
    static_image_directory: "netbox_topology_views/img"
```

Netbox's configuration.py is rendered as follows:

```python
PLUGINS_CONFIG = {
    'netbox_config_diff': {
        'USERNAME': 'admin',
        'PASSWORD': 'YourPaSsWoRd',
    }
    'netbox_topology_views': {
        'static_image_directory': 'netbox_topology_views/img',
    }
}
```

A comma between two dict items is missing. 

This PR fixes the above 