### PR TITLE
wireguard: add wireguard_dns parameter

### DIFF
--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -7,3 +7,4 @@ wireguard_server_public_address: WIREGUARD_PUBLIC_IP_ADDRESS
 wireguard_endpoint: "{{ wireguard_server_public_address }}:{{ wireguard_listen_port }}"
 wireguard_create_client_config: false
 wireguard_client_allowed_ips: "192.168.16.0/20,172.31.252.0/23,10.43.0.0/16,192.168.112.0/20,192.168.128.0/20"
+wireguard_dns:

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -2,6 +2,9 @@
 MTU = {{ wireguard_mtu }}
 PrivateKey = CHANGEME - {{ item.name }} private key
 Address = {{ item.ip }}
+{% if wireguard_dns is defined and wireguard_dns | length > 0 %}
+DNS = {{ wireguard_dns }}
+{% endif %}
 
 [Peer]
 PublicKey = {{ wireguard_public_key_server['content']|b64decode }}


### PR DESCRIPTION
With the wireguard_dns parameter it is possible to set the DNS server.

Related to osism/cloud-in-a-box#336