### PR TITLE
wireguard: use empty string as default for wiregurad_dns

### DIFF
--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -7,4 +7,4 @@ wireguard_server_public_address: WIREGUARD_PUBLIC_IP_ADDRESS
 wireguard_endpoint: "{{ wireguard_server_public_address }}:{{ wireguard_listen_port }}"
 wireguard_create_client_config: false
 wireguard_client_allowed_ips: "192.168.16.0/20,172.31.252.0/23,10.43.0.0/16,192.168.112.0/20,192.168.128.0/20"
-wireguard_dns:
+wireguard_dns: ""


### PR DESCRIPTION
This will avoid the following issue:

object of type 'NoneType' has no len(). object of type 'NoneType' has no len()