### PR TITLE
Remove usage of `osism_netbox_image` in manager role

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -238,9 +238,6 @@ celery_enable: true
 osism_tag: latest
 osism_image: "{{ docker_registry_osism }}/osism/osism:{{ osism_tag }}"
 
-osism_netbox_tag: latest
-osism_netbox_image: "{{ docker_registry_osism_netbox }}/osism/osism-netbox:{{ osism_netbox_tag }}"
-
 flower_host: "{{ ansible_default_ipv4.address }}"
 flower_port: 5555
 flower_traefik: false

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -136,7 +136,7 @@ services:
 
   netbox:
     restart: unless-stopped
-    image: "{{ osism_netbox_image }}"
+    image: "{{ osism_image }}"
     command: osism worker netbox
     volumes:
       - "{{ _manager_ca_certificates_file }}:/etc/ssl/certs/ca-certificates.crt:ro"


### PR DESCRIPTION
The `osism_netbox_image` is no longer build and replaced with the generic `osism_image`.

Part of https://github.com/osism/issues/issues/1223