### PR TITLE
Add netbox custom field for ironic parameters

### DIFF
--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -170,6 +170,7 @@ services:
       - "{{ _manager_ca_certificates_file }}:/etc/ssl/certs/ca-certificates.crt:ro"
       - "{{ manager_configuration_directory }}/conductor.yml:/etc/conductor.yml:ro"
       - "{{ state_directory }}/conductor:/state:rw"
+      - "share:/share"
     secrets:
       - NETBOX_TOKEN
     healthcheck:

--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -26,3 +26,12 @@ power_state:
   weight: 0
   on_objects:
     - dcim.models.Device
+
+ironic_parameters:
+  type: json
+  label: Ironic parameters
+  description: Ironic parameters
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device


### PR DESCRIPTION
Add a custom field to netbox devices to allow to overwrite ironic parameters set in the manager's `conductor.yml`.

Part of https://github.com/osism/issues/issues/1224