### PR TITLE
netbox: add custom field frr_local_as

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -19,6 +19,16 @@ dnsmasq_dhcp_tag:
     - dcim.models.Device
   ui_visibility: hidden-ifunset
 
+frr_local_as:
+  type: text
+  label: FRR local AS
+  description: Overwrite the default FRR local AS
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+  ui_visibility: hidden-ifunset
+
 provision_state:
   type: text
   label: Provision state


### PR DESCRIPTION
Allow to overwrite the default FRR local AS (based on the primary IP address).