### PR TITLE
netbox: remove OOB Leaf device role

### DIFF
--- a/roles/netbox/templates/initializers/device_roles.yml.j2
+++ b/roles/netbox/templates/initializers/device_roles.yml.j2
@@ -68,9 +68,6 @@
 - name: Transfer Leaf
   slug: transferleaf
   color: yellow
-- name: OOB Leaf
-  slug: oobleaf
-  color: yellow
 
 - name: OOB
   slug: oob


### PR DESCRIPTION
An OOB Leaf is an Access Leaf with the out-of-band tag.