### PR TITLE
manager: make it possible to set the inventory-reconciler mode

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -122,6 +122,8 @@ inventory_reconciler_tag: latest
 inventory_reconciler_image_namespace: osism
 inventory_reconciler_image: "{{ docker_registry_inventory_reconciler }}/{{ inventory_reconciler_image_namespace }}/inventory-reconciler:{{ inventory_reconciler_tag }}"
 
+manager_inventory_reconciler_mode: manager
+
 ##########################
 # ansible services
 

--- a/roles/manager/templates/env/inventory-reconciler.env.j2
+++ b/roles/manager/templates/env/inventory-reconciler.env.j2
@@ -1,3 +1,4 @@
+INVENTORY_RECONCILER_MODE={{ manager_inventory_reconciler_mode }}
 {% if netbox_data_types | length > 0 %}
 NETBOX_DATA_TYPES='@json {{ netbox_data_types | to_json }}'
 {% endif %}


### PR DESCRIPTION
With manager_inventory_reconciler_mode it's possible to set the mode of the inventory reconciler. Supported values are manager and metalbox at the moment.