### PR TITLE
netbox: make it possible to skip service restarts

### DIFF
--- a/roles/netbox/defaults/main.yml
+++ b/roles/netbox/defaults/main.yml
@@ -37,6 +37,7 @@ netbox_network: 172.31.100.176/28
 netbox_old_service_name: "docker-compose@netbox"
 netbox_service_name: "netbox"
 
+netbox_service_allow_restart: true
 netbox_pre_pull: true
 
 netbox_host: 127.0.0.1

--- a/roles/netbox/handlers/main.yml
+++ b/roles/netbox/handlers/main.yml
@@ -8,6 +8,7 @@
 
 - name: Restart netbox service
   ansible.builtin.include_tasks: restart-service.yml
+  when: netbox_service_allow_restart | bool
 
 - name: Wait for an healthy netbox service
   ansible.builtin.include_tasks: wait-for-healthy-service.yml


### PR DESCRIPTION
Set netbox_service_allow_restart = false to skip service restarts.