### PR TITLE
manager: add manager_service_manual_start parameter

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -25,6 +25,7 @@ manager_network: 172.31.101.0/27
 manager_old_service_name: "docker-compose@manager"
 manager_service_name: "manager"
 
+manager_service_manual_start: false
 manager_service_allow_restart: true
 manager_pre_pull: true
 

--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -50,6 +50,12 @@
     state: stopped
     enabled: false
 
+- name: Do a manual start of the manager service
+  ansible.builtin.command: "/usr/bin/docker compose --project-directory {{ manager_docker_compose_directory }} up -d --remove-orphans"
+  changed_when: true
+  notify: Wait for an healthy manager service
+  when: manager_service_manual_start | bool
+
 - name: Ensure that the manager service is up and running
   block:  # noqa osism-fqcn
     - name: Manage manager service


### PR DESCRIPTION
The manager_service_manual_start parameter allows to do a manual start with docker compose. Sometimes this is more reliable when deploying the manager the first time.