### PR TITLE
manager: make it possible to disable the watchdog service

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -342,6 +342,11 @@ enable_listener: false
 manager_listener_broker_uri: "amqp://openstack:password@127.0.0.1:5672/"
 
 ##########################
+# watchdog
+
+manager_enable_watchdog: true
+
+##########################
 # openstack
 
 manager_enable_openstack: true

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -254,6 +254,7 @@ services:
 {% endif %}
 {% endif %}
 
+{% if manager_enable_watchdog|bool %}
   ##########################################
   # watchdog service
 
@@ -265,6 +266,7 @@ services:
       - "{{ configuration_directory }}:/opt/configuration:ro"
     healthcheck:
       test: pgrep osism
+{% endif %}
 
   ##########################################
   # api service


### PR DESCRIPTION
With the boolean parameter manager_enable_watchdog it's possible to configure the watchdog service.