### PR TITLE
netbox: add secrets custom field for devices

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -99,3 +99,13 @@ dnsmasq_parameters:
   on_objects:
     - dcim.models.Device
   ui_visibility: hidden-ifunset
+
+secrets:
+  type: text
+  label: secrets
+  description: Device specific secrets (Ansible vault encrypted)
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+  ui_visibility: hidden-ifunset


### PR DESCRIPTION
Add a text custom field to store device-specific secrets (Ansible vault encrypted) in NetBox. The field is optional and hidden unless set.