### PR TITLE
manager: fix stdin handling in osism wrapper

### DIFF
--- a/roles/manager/templates/wrapper/osism.j2
+++ b/roles/manager/templates/wrapper/osism.j2
@@ -16,7 +16,7 @@ fi
 
 if [[ $INTERACTIVE == "true" ]]; then
 
-    PARAMETERS="$PARAMETERS -it"
+    PARAMETERS="$PARAMETERS -t"
 
 fi
 
@@ -45,4 +45,4 @@ if [[ -n "$OSISM_RETRY" ]]; then
     PARAMETERS="$PARAMETERS --env OSISM_RETRY=$OSISM_RETRY"
 fi
 
-docker exec $PARAMETERS osismclient osism "$@"
+docker exec -i $PARAMETERS osismclient osism "$@"


### PR DESCRIPTION
Split the -it flag into separate -i and -t flags. Always enable stdin (-i) but only allocate a pseudo-TTY (-t) when running in interactive mode. This ensures proper stdin handling for non-interactive commands while preserving TTY allocation for interactive sessions.