### PR TITLE
dnsmasq: add dhcp-boot configuration support

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -25,7 +25,9 @@ dnsmasq_dhcp_macs: []
 dnsmasq_dhcp_options: []
 dnsmasq_dynamic_hosts: []
 # example: - metalbox,192.168.42.0/24,192.168.42.10
+dnsmasq_dhcp_boot: []
 
+dnsmasq_dhcp_boot_groups: generic
 dnsmasq_dhcp_hosts_groups: generic
 dnsmasq_dhcp_macs_groups: generic
 dnsmasq_dhcp_options_groups: generic

--- a/roles/dnsmasq/tasks/config.yml
+++ b/roles/dnsmasq/tasks/config.yml
@@ -7,6 +7,10 @@
   ansible.builtin.set_fact:
     _dnsmasq_dynamic_hosts: "{{ lookup('community.general.merge_variables', '^dnsmasq_dynamic_hosts__.+$', initial_value=dnsmasq_dynamic_hosts, groups=dnsmasq_dynamic_hosts_groups) }}"  # yamllint disable-line rule:line-length
 
+- name: Set _dnsmasq_dhcp_boot fact
+  ansible.builtin.set_fact:
+    _dnsmasq_dhcp_boot: "{{ lookup('community.general.merge_variables', '^dnsmasq_dhcp_boot__.+$', initial_value=dnsmasq_dhcp_boot, groups=dnsmasq_dhcp_boot_groups) }}"  # yamllint disable-line rule:line-length
+
 - name: Set _dnsmasq_dhcp_hosts fact
   ansible.builtin.set_fact:
     _dnsmasq_dhcp_hosts: "{{ lookup('community.general.merge_variables', '^dnsmasq_dhcp_hosts__.+$', initial_value=dnsmasq_dhcp_hosts, groups=dnsmasq_dhcp_hosts_groups) }}"  # yamllint disable-line rule:line-length

--- a/roles/dnsmasq/templates/dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/dnsmasq.conf.j2
@@ -11,6 +11,9 @@ dhcp-host={{ dhcp_host }}
 {% for dhcp_mac in _dnsmasq_dhcp_macs %}
 dhcp-mac={{ dhcp_mac }}
 {% endfor %}
+{% for dhcp_boot in _dnsmasq_dhcp_boot %}
+dhcp-boot={{ dhcp_boot }}
+{% endfor %}
 {% for dhcp_option in _dnsmasq_dhcp_options %}
 dhcp-option={{ dhcp_option }}
 {% endfor %}


### PR DESCRIPTION
Enable network boot (PXE) capabilities by adding support for dhcp-boot options. This allows configuration through the dnsmasq_dhcp_boot variable with group-based merging support similar to other dhcp options.