### PR TITLE
httpd: add SONiC ZTP support

### DIFF
--- a/molecule/delegated/vars/httpd.yml
+++ b/molecule/delegated/vars/httpd.yml
@@ -3,3 +3,6 @@ operator_user: zuul
 operator_group: zuul
 
 httpd_data_enable: true
+httpd_sonic_ztp_enable: true
+
+httpd_sonic_ztp_authorized_keys: ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHAsus5/h/wwuUKr1c9/6UFZe7T0oh6Zsv8gSoQvpMaR test@test.test"]

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -29,6 +29,9 @@ httpd_image: "{{ httpd_docker_registry }}/httpd:{{ httpd_tag }}"
 
 httpd_container_name: httpd
 
+##########################
+# data import
+
 httpd_data_uid: "{{ ansible_facts.user_uid }}"
 httpd_data_gid: "{{ ansible_facts.user_gid }}"
 
@@ -36,3 +39,19 @@ httpd_data_enable: false
 httpd_data_docker_registry: registry.osism.tech
 httpd_data_tag: latest
 httpd_data_image: "{{ httpd_data_docker_registry }}/osism/rsync:{{ httpd_data_tag }}"
+
+##########################
+# sonic ztp
+
+http_sonic_ztp_enable: false
+
+httpd_sonic_ztp_hostname: metalbox
+httpd_sonic_ztp_firmware: sonic-broadcom-enterprise-base.bin
+httpd_sonic_ztp_directory: sonic
+
+httpd_sonic_ztp_configdb_prefix: osism_
+httpd_sonic_ztp_configdb_identifier: hostname
+httpd_sonic_ztp_configdb_suffix: _config_db.json
+
+httpd_sonic_ztp_authorized_keys: []
+httpd_sonic_ztp_authorized_keys_delete: []

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -34,6 +34,10 @@
     state: started
   when: httpd_data_enable | bool
 
+- name: Include sonic-ztp tasks
+  ansible.builtin.include_tasks: sonic-ztp.yml
+  when: httpd_sonic_ztp_enable | bool
+
 - name: Copy docker-compose.yml file
   ansible.builtin.template:
     src: docker-compose.yml.j2

--- a/roles/httpd/tasks/sonic-ztp.yml
+++ b/roles/httpd/tasks/sonic-ztp.yml
@@ -1,0 +1,41 @@
+---
+- name: Create sonic-ztp directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0755
+  loop:
+    - "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}"
+
+- name: Set ssh authorized keys
+  ansible.posix.authorized_key:
+    key: "{{ item }}"
+    user: "{{ operator_user }}"
+    path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/authorized_keys"
+  loop: "{{ httpd_sonic_ztp_authorized_keys }}"
+  no_log: true
+
+- name: Delete ssh authorized keys
+  ansible.posix.authorized_key:
+    key: "{{ item }}"
+    user: "{{ operator_user }}"
+    path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/authorized_keys"
+    state: absent
+  loop: "{{ httpd_sonic_ztp_authorized_keys_delete }}"
+  no_log: true
+
+- name: Make authorized_keys file world readable
+  ansible.builtin.file:
+    path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/authorized_keys"
+    mode: 0644
+
+- name: Copy ztp.json file
+  ansible.builtin.template:
+    src: ztp.json.j2
+    dest: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/ztp.json"
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0644

--- a/roles/httpd/templates/ztp.json.j2
+++ b/roles/httpd/templates/ztp.json.j2
@@ -1,0 +1,30 @@
+{
+  "ztp": {
+    "01-firmware": {
+      "install": {
+        "url": "http://{{ httpd_sonic_ztp_hostname }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_firmware }}",
+        "set-default": true
+      },
+      "reboot-on-success": true
+    },
+    "02-download": {
+      "files": [
+        {
+          "url": {
+            "source": "http://{{ httpd_sonic_ztp_hostname }}/{{ httpd_sonic_ztp_directory }}/authorized_keys",
+            "destination": "/home/admin/.ssh/authorized_keys"
+          }
+        }
+      ]
+    },
+    "03-configdb-json": {
+      "dynamic-url": {
+        "source": {
+          "prefix": "http://{{ httpd_sonic_ztp_hostname }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_configdb_prefix }}",
+          "identifier": "{{ httpd_sonic_ztp_configdb_identifier }}",
+          "suffix": "{{ httpd_sonic_ztp_configdb_suffix }}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Zero Touch Provisioning (ZTP) capability for SONiC switches through the httpd role. This enables automated firmware installation, SSH key deployment, and configuration database provisioning via HTTP.