### PR TITLE
netbox: add sonic_parameters custom field

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -109,3 +109,14 @@ secrets:
   on_objects:
     - dcim.models.Device
   ui_visibility: hidden-ifunset
+
+sonic_parameters:
+  type: json
+  label: sonic parameters
+  description: SONiC parameters
+  required: false
+  weight: 0
+  on_objects:
+    - dcim.models.Device
+    - dcim.models.Interface
+  ui_visibility: hidden-ifunset


### PR DESCRIPTION
Add a new JSON custom field to store SONiC-specific parameters that can be attached to both Device and Interface objects.