### PR TITLE
manager: split netbox_filter_conductor into ironic and sonic filters

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -87,10 +87,14 @@ netbox_secondaries: []
 #     NETBOX_TOKEN: <secondary netbox API token>
 #     IGNORE_SSL_ERRORS: <'True'|'False'>
 #   - ...
-netbox_filter_conductor:
+netbox_filter_conductor_ironic:
   - state: active
     tag:
       - managed-by-ironic
+netbox_filter_conductor_sonic:
+  - state: active
+    tag:
+      - managed-by-metalbox
 netbox_filter_inventory:
   - state: active
     tag:

--- a/roles/manager/templates/env/conductor.env.j2
+++ b/roles/manager/templates/env/conductor.env.j2
@@ -1,4 +1,7 @@
 ENABLE_IRONIC={{ manager_enable_ironic }}
-{% if netbox_filter_conductor | length > 0 %}
-NETBOX_FILTER_CONDUCTOR="{{ netbox_filter_conductor | to_nice_yaml(indent=2) }}"
+{% if netbox_filter_conductor_ironic | length > 0 %}
+NETBOX_FILTER_CONDUCTOR_IRONIC="{{ netbox_filter_conductor_ironic | to_nice_yaml(indent=2) }}"
+{% endif %}
+{% if netbox_filter_conductor_sonic | length > 0 %}
+NETBOX_FILTER_CONDUCTOR_SONIC="{{ netbox_filter_conductor_sonic | to_nice_yaml(indent=2) }}"
 {% endif %}


### PR DESCRIPTION
Split the single netbox_filter_conductor into separate filters for Ironic and SONiC to allow independent filtering. The Ironic filter uses the managed-by-ironic tag while the SONiC filter uses the managed-by-metalbox tag.