### PR TITLE
dnsmasq: add dhcp-vendorclass support

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -27,6 +27,7 @@ dnsmasq_dynamic_hosts: []
 # example: - metalbox,192.168.42.0/24,192.168.42.10
 dnsmasq_dhcp_boot: []
 dnsmasq_dhcp_userclass: []
+dnsmasq_dhcp_vendorclass: []
 
 dnsmasq_dhcp_boot_groups: generic
 dnsmasq_dhcp_hosts_groups: generic
@@ -34,6 +35,7 @@ dnsmasq_dhcp_macs_groups: generic
 dnsmasq_dhcp_options_groups: generic
 dnsmasq_dhcp_ranges_groups: generic
 dnsmasq_dhcp_userclass_groups: generic
+dnsmasq_dhcp_vendorclass_groups: generic
 dnsmasq_dynamic_hosts_groups: generic
 dnsmasq_interfaces_groups: generic
 

--- a/roles/dnsmasq/tasks/config.yml
+++ b/roles/dnsmasq/tasks/config.yml
@@ -31,6 +31,10 @@
   ansible.builtin.set_fact:
     _dnsmasq_dhcp_userclass: "{{ lookup('community.general.merge_variables', '^dnsmasq_dhcp_userclass__.+$', initial_value=dnsmasq_dhcp_userclass, groups=dnsmasq_dhcp_userclass_groups) }}"  # yamllint disable-line rule:line-length
 
+- name: Set _dnsmasq_dhcp_vendorclass fact
+  ansible.builtin.set_fact:
+    _dnsmasq_dhcp_vendorclass: "{{ lookup('community.general.merge_variables', '^dnsmasq_dhcp_vendorclass__.+$', initial_value=dnsmasq_dhcp_vendorclass, groups=dnsmasq_dhcp_vendorclass_groups) }}"  # yamllint disable-line rule:line-length
+
 - name: Create required directories
   become: true
   ansible.builtin.file:

--- a/roles/dnsmasq/templates/dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/dnsmasq.conf.j2
@@ -14,6 +14,9 @@ dhcp-mac={{ dhcp_mac }}
 {% for dhcp_userclass in _dnsmasq_dhcp_userclass %}
 dhcp-userclass={{ dhcp_userclass }}
 {% endfor %}
+{% for dhcp_vendorclass in _dnsmasq_dhcp_vendorclass %}
+dhcp-vendorclass={{ dhcp_vendorclass }}
+{% endfor %}
 {% for dhcp_boot in _dnsmasq_dhcp_boot %}
 dhcp-boot={{ dhcp_boot }}
 {% endfor %}


### PR DESCRIPTION
Add support for DHCP vendor class configuration in dnsmasq role with new dnsmasq_dhcp_vendorclass variable and template support.