### PR TITLE
httpd: add support for grouped IP allowlists in SONiC ZTP mode

### DIFF
--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -57,3 +57,4 @@ httpd_sonic_ztp_authorized_keys: []
 httpd_sonic_ztp_authorized_keys_delete: []
 
 httpd_sonic_ztp_allowed_ip: []
+httpd_sonic_ztp_allowed_ip_groups: generic

--- a/roles/httpd/tasks/sonic-ztp.yml
+++ b/roles/httpd/tasks/sonic-ztp.yml
@@ -56,6 +56,10 @@
     group: "{{ operator_group }}"
     mode: 0755
 
+- name: Set _httpd_sonic_ztp_allowed_ip fact
+  ansible.builtin.set_fact:
+    _httpd_sonic_ztp_allowed_ip: "{{ lookup('community.general.merge_variables', '^httpd_sonic_ztp_allowed_ip__.+$', initial_value=httpd_sonic_ztp_allowed_ip, groups=httpd_sonic_ztp_allowed_ip_groups) }}"  # yamllint disable-line rule:line-length
+
 - name: Copy .htaccess file
   ansible.builtin.template:
     src: htaccess.j2
@@ -63,10 +67,10 @@
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
     mode: 0644
-  when: httpd_sonic_ztp_allowed_ip | length > 0
+  when: _httpd_sonic_ztp_allowed_ip | length > 0
 
 - name: Remove .htaccess file
   ansible.builtin.file:
     path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/.htaccess"
     state: absent
-  when: not httpd_sonic_ztp_allowed_ip
+  when: not _httpd_sonic_ztp_allowed_ip

--- a/roles/httpd/templates/htaccess.j2
+++ b/roles/httpd/templates/htaccess.j2
@@ -1,5 +1,5 @@
 <RequireAny>
-{% for allowed_ip in httpd_sonic_ztp_allowed_ip %}
+{% for allowed_ip in _httpd_sonic_ztp_allowed_ip %}
 Require ip {{ allowed_ip }}
 {% endfor %}
 </RequireAny>


### PR DESCRIPTION
This change introduces the ability to manage allowed IPs for SONiC ZTP through group/host variables by adding httpd_sonic_ztp_allowed_ip_groups configuration and using merge_variables lookup to combine IP lists.