### PR TITLE
Revert "dnsmasq: ignore some extra vars in metalbox mode"

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -15,8 +15,6 @@ dnsmasq_docker_compose_directory: /opt/dnsmasq
 dnsmasq_service_name: "docker-compose@dnsmasq"
 dnsmasq_container_name: dnsmasq
 
-dnsmasq_mode: default
-
 dnsmasq_interfaces:
   - "{{ ansible_default_ipv4.interface }}"
 dnsmasq_dhcp_ranges: []

--- a/roles/dnsmasq/tasks/config.yml
+++ b/roles/dnsmasq/tasks/config.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ignore some extra vars in metalbox mode
-  ansible.builtin.set_fact:
-    dnsmasq_dhcp_options: []
-    dnsmasq_dhcp_boot: []
-  when: dnsmasq_mode == "metalbox"
-
 - name: Set _dnsmasq_interfaces fact
   ansible.builtin.set_fact:
     _dnsmasq_interfaces: "{{ lookup('community.general.merge_variables', '^dnsmasq_interfaces__.+$', initial_value=dnsmasq_interfaces, groups=dnsmasq_interfaces_groups) }}"  # yamllint disable-line rule:line-length


### PR DESCRIPTION
This reverts commit c15d75ed4932e52f3c35be0a3cf957053c419939.