### PR TITLE
httpd: bind to all global IPv6 addresses

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -54,8 +54,8 @@
 
 - name: Set _httpd_loopback_ipv4 and _httpd_loopback_ipv6 facts
   ansible.builtin.set_fact:
-    _httpd_loopback_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + httpd_ironic_interface]['ipv4']['address'] | default('') }}"
-    _httpd_loopback_ipv6: "{{ hostvars[inventory_hostname]['ansible_' + httpd_ironic_interface]['ipv6'][0]['address'] | default('') }}"
+    _httpd_loopback_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + httpd_ironic_interface]['ipv4']['address'] | default('') if ('ansible_' + httpd_ironic_interface) in hostvars[inventory_hostname] else '' }}"
+    _httpd_loopback_ipv6: "{{ hostvars[inventory_hostname]['ansible_' + httpd_ironic_interface]['ipv6'] | selectattr('scope', 'equalto', 'global') | map(attribute='address') | list if ('ansible_' + httpd_ironic_interface) in hostvars[inventory_hostname] else [] }}"
   when: httpd_ironic_enable | bool
 
 - name: Copy docker-compose.yml file

--- a/roles/httpd/templates/docker-compose.yml.j2
+++ b/roles/httpd/templates/docker-compose.yml.j2
@@ -10,9 +10,9 @@ services:
 {% if _httpd_loopback_ipv4 | length %}
       - "{{ _httpd_loopback_ipv4 }}:{{ httpd_ironic_port }}:{{ httpd_ironic_port }}"
 {% endif %}
-{% if _httpd_loopback_ipv6 | length %}
-      - "[{{ _httpd_loopback_ipv6 }}]:{{ httpd_ironic_port }}:{{ httpd_ironic_port }}"
-{% endif %}
+{% for ipv6_addr in _httpd_loopback_ipv6 %}
+      - "[{{ ipv6_addr }}]:{{ httpd_ironic_port }}:{{ httpd_ironic_port }}"
+{% endfor %}
 {% endif %}
     volumes:
 {% if httpd_ironic_enable | bool %}


### PR DESCRIPTION
Changes _httpd_loopback_ipv6 fact to collect all IPv6 addresses with global scope from the interface instead of just the first one. Updates docker-compose template to iterate through all collected IPv6 addresses when binding ports.

AI-assisted: Claude Code