### PR TITLE
netbox: change default value of maintenance from false to true

### DIFF
--- a/roles/netbox/templates/initializers/custom_fields.yml.j2
+++ b/roles/netbox/templates/initializers/custom_fields.yml.j2
@@ -2,7 +2,7 @@
 maintenance:
   type: boolean
   label: Maintenance
-  default: false
+  default: true
   description: Maintenance
   required: false
   weight: 0


### PR DESCRIPTION
New nodes should be in maintenance state by default. The maintenance state is synced with the maintenance state in Ironic.