### PR TITLE
nexus: add default filter to prevent undefined variable errors

### DIFF
--- a/roles/nexus/tasks/initialize.yml
+++ b/roles/nexus/tasks/initialize.yml
@@ -91,7 +91,7 @@
           {{
             _nexus_repos_global_list | default([])
             +
-            (nexus_repos_docker_proxy | map('combine', {"format": "docker", "type": "proxy"}) | list)
+            (nexus_repos_docker_proxy | default([]) | map('combine', {"format": "docker", "type": "proxy"}) | list)
           }}
 
 - name: Process definitions for apt repositories  # noqa: osism-fqcn
@@ -110,7 +110,7 @@
           {{
             _nexus_repos_global_list | default([])
             +
-            (nexus_repos_apt_proxy | map('combine', {"format": "apt", "type": "proxy"}) | list)
+            (nexus_repos_apt_proxy | default([]) | map('combine', {"format": "apt", "type": "proxy"}) | list)
           }}
 
 - name: Create configured repositories


### PR DESCRIPTION
Added default([]) filter to nexus_repos_docker_proxy and nexus_repos_apt_proxy variables to prevent template errors when these variables are undefined.

AI-assisted: Claude Code