### PR TITLE
Revert "chore(deps): update dependency python to 3.13 (#1970)"

### DIFF
--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python3 -m pip install ansible-core~=2.12.3


### PR DESCRIPTION
This reverts commit 340f9771656292038c94d2e33257f264d243699c.

Does not work with current Ansible version.