### PR TITLE
frr: Add optional BFD support for FRR neighbors

### DIFF
--- a/roles/frr/defaults/main.yml
+++ b/roles/frr/defaults/main.yml
@@ -76,6 +76,20 @@ frr_options_vrrpd: "-A 127.0.0.1"
 # When defined, this takes precedence over all other configuration sources.
 # frr_config_template:
 
+# BFD (Bidirectional Forwarding Detection) profiles
+# Optional BFD configuration for fast failure detection
+# Example configuration:
+# frr_bfd_profiles:
+#   - name: fast
+#     receive_interval: 300
+#     transmit_interval: 300
+#     detect_multiplier: 3
+#   - name: slow
+#     receive_interval: 1000
+#     transmit_interval: 1000
+#     detect_multiplier: 5
+frr_bfd_profiles: []
+
 frr_config_file: "/etc/frr/frr.conf"
 frr_vtysh_file: "/etc/frr/vtysh.conf"
 frr_daemons_file: "/etc/frr/daemons"

--- a/roles/frr/templates/frr_k3s_cilium.conf.j2
+++ b/roles/frr/templates/frr_k3s_cilium.conf.j2
@@ -4,6 +4,19 @@ hostname {{ frr_hostname }}
 log syslog informational
 service integrated-vtysh-config
 !
+{# BFD profile configuration if defined #}
+{% if frr_bfd_profiles is defined and frr_bfd_profiles | length > 0 %}
+bfd
+{% for profile in frr_bfd_profiles %}
+ profile {{ profile.name }}
+  receive-interval {{ profile.receive_interval }}
+  transmit-interval {{ profile.transmit_interval }}
+  detect-multiplier {{ profile.detect_multiplier }}
+ exit
+{% endfor %}
+exit
+!
+{% endif %}
 router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
@@ -15,6 +28,12 @@ router bgp {{ frr_local_as }}
 {% endif %}
  neighbor {{ item.address }} update-source {{ item.interface }}
  neighbor {{ item.address }} soft-reconfiguration inbound
+{# Enable BFD for neighbor if configured #}
+{% if item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
+{% elif item.bfd_profile is defined %}
+ neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
+{% endif %}
 {% endfor %}
  !
  address-family ipv4 unicast

--- a/roles/frr/templates/frr_k3s_cilium.conf.j2
+++ b/roles/frr/templates/frr_k3s_cilium.conf.j2
@@ -29,10 +29,10 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.address }} update-source {{ item.interface }}
  neighbor {{ item.address }} soft-reconfiguration inbound
 {# Enable BFD for neighbor if configured #}
-{% if item.bfd is defined and item.bfd %}
- neighbor {{ item.address }} bfd
-{% elif item.bfd_profile is defined %}
+{% if item.bfd_profile is defined %}
  neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
+{% elif item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
 {% endif %}
 {% endfor %}
  !
@@ -42,6 +42,4 @@ router bgp {{ frr_local_as }}
 {% endfor %}
  exit-address-family
  !
- address-family ipv6 unicast
- exit-address-family
 exit

--- a/roles/frr/templates/frr_leaf.conf.j2
+++ b/roles/frr/templates/frr_leaf.conf.j2
@@ -27,10 +27,10 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.interface }} password {{ item.password }}
 {% endif %}
 {# Enable BFD for neighbor if configured #}
-{% if item.bfd is defined and item.bfd %}
- neighbor {{ item.interface }} bfd
-{% elif item.bfd_profile is defined %}
+{% if item.bfd_profile is defined %}
  neighbor {{ item.interface }} bfd profile {{ item.bfd_profile }}
+{% elif item.bfd is defined and item.bfd %}
+ neighbor {{ item.interface }} bfd
 {% endif %}
 {% endfor %}
  !

--- a/roles/frr/templates/frr_leaf.conf.j2
+++ b/roles/frr/templates/frr_leaf.conf.j2
@@ -4,6 +4,19 @@ hostname {{ frr_hostname }}
 log syslog informational
 service integrated-vtysh-config
 !
+{# BFD profile configuration if defined #}
+{% if frr_bfd_profiles is defined and frr_bfd_profiles | length > 0 %}
+bfd
+{% for profile in frr_bfd_profiles %}
+ profile {{ profile.name }}
+  receive-interval {{ profile.receive_interval }}
+  transmit-interval {{ profile.transmit_interval }}
+  detect-multiplier {{ profile.detect_multiplier }}
+ exit
+{% endfor %}
+exit
+!
+{% endif %}
 router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
@@ -12,6 +25,12 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.interface }} interface remote-as {{ item.remote_as }}
 {% if "password" in item %}
  neighbor {{ item.interface }} password {{ item.password }}
+{% endif %}
+{# Enable BFD for neighbor if configured #}
+{% if item.bfd is defined and item.bfd %}
+ neighbor {{ item.interface }} bfd
+{% elif item.bfd_profile is defined %}
+ neighbor {{ item.interface }} bfd profile {{ item.bfd_profile }}
 {% endif %}
 {% endfor %}
  !

--- a/roles/frr/templates/frr_loadbalancer.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer.conf.j2
@@ -4,6 +4,19 @@ hostname {{ frr_hostname }}
 log syslog informational
 service integrated-vtysh-config
 !
+{# BFD profile configuration if defined #}
+{% if frr_bfd_profiles is defined and frr_bfd_profiles | length > 0 %}
+bfd
+{% for profile in frr_bfd_profiles %}
+ profile {{ profile.name }}
+  receive-interval {{ profile.receive_interval }}
+  transmit-interval {{ profile.transmit_interval }}
+  detect-multiplier {{ profile.detect_multiplier }}
+ exit
+{% endfor %}
+exit
+!
+{% endif %}
 router bgp {{ frr_local_as }}
  bgp router-id {{ frr_loopback_v4 }}
  no bgp ebgp-requires-policy
@@ -13,11 +26,23 @@ router bgp {{ frr_local_as }}
 {% if "password" in item %}
  neighbor {{ item.address }} password {{ item.password }}
 {% endif %}
+{# Enable BFD for IPv4 neighbor if configured #}
+{% if item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
+{% elif item.bfd_profile is defined %}
+ neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
+{% endif %}
 {% endfor %}
 {% for item in frr_neigh_v6 %}
  neighbor {{ item.address }} remote-as {{ item.remote_as }}
 {% if "password" in item %}
  neighbor {{ item.address }} password {{ item.password }}
+{% endif %}
+{# Enable BFD for IPv6 neighbor if configured #}
+{% if item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
+{% elif item.bfd_profile is defined %}
+ neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
 {% endif %}
 {% endfor %}
  !

--- a/roles/frr/templates/frr_loadbalancer.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer.conf.j2
@@ -27,10 +27,10 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.address }} password {{ item.password }}
 {% endif %}
 {# Enable BFD for IPv4 neighbor if configured #}
-{% if item.bfd is defined and item.bfd %}
- neighbor {{ item.address }} bfd
-{% elif item.bfd_profile is defined %}
+{% if item.bfd_profile is defined %}
  neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
+{% elif item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
 {% endif %}
 {% endfor %}
 {% for item in frr_neigh_v6 %}
@@ -39,10 +39,10 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.address }} password {{ item.password }}
 {% endif %}
 {# Enable BFD for IPv6 neighbor if configured #}
-{% if item.bfd is defined and item.bfd %}
- neighbor {{ item.address }} bfd
-{% elif item.bfd_profile is defined %}
+{% if item.bfd_profile is defined %}
  neighbor {{ item.address }} bfd profile {{ item.bfd_profile }}
+{% elif item.bfd is defined and item.bfd %}
+ neighbor {{ item.address }} bfd
 {% endif %}
 {% endfor %}
  !

--- a/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
@@ -27,10 +27,10 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.interface }} password {{ item.password }}
 {% endif %}
 {# Enable BFD for neighbor if configured #}
-{% if item.bfd is defined and item.bfd %}
- neighbor {{ item.interface }} bfd
-{% elif item.bfd_profile is defined %}
+{% if item.bfd_profile is defined %}
  neighbor {{ item.interface }} bfd profile {{ item.bfd_profile }}
+{% elif item.bfd is defined and item.bfd %}
+ neighbor {{ item.interface }} bfd
 {% endif %}
 {% endfor %}
  !

--- a/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
@@ -4,6 +4,19 @@ hostname {{ frr_hostname }}
 log syslog informational
 service integrated-vtysh-config
 !
+{# BFD profile configuration if defined #}
+{% if frr_bfd_profiles is defined and frr_bfd_profiles | length > 0 %}
+bfd
+{% for profile in frr_bfd_profiles %}
+ profile {{ profile.name }}
+  receive-interval {{ profile.receive_interval }}
+  transmit-interval {{ profile.transmit_interval }}
+  detect-multiplier {{ profile.detect_multiplier }}
+ exit
+{% endfor %}
+exit
+!
+{% endif %}
 router bgp {{ frr_local_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
@@ -12,6 +25,12 @@ router bgp {{ frr_local_as }}
  neighbor {{ item.interface }} interface remote-as {{ item.remote_as }}
 {% if "password" in item %}
  neighbor {{ item.interface }} password {{ item.password }}
+{% endif %}
+{# Enable BFD for neighbor if configured #}
+{% if item.bfd is defined and item.bfd %}
+ neighbor {{ item.interface }} bfd
+{% elif item.bfd_profile is defined %}
+ neighbor {{ item.interface }} bfd profile {{ item.bfd_profile }}
 {% endif %}
 {% endfor %}
  !


### PR DESCRIPTION
Add optional BFD (Bidirectional Forwarding Detection) configuration for BGP neighbors in FRR role.

- Add frr_bfd_profiles variable to defaults/main.yml with example configuration
- Update all FRR templates to support BFD profile configuration
- Add per-neighbor BFD enablement via 'bfd' or 'bfd_profile' attributes
- Support both interface-based and IP-based BGP neighbors
- Maintain backward compatibility - BFD is completely optional