### PR TITLE
dnsmasq: use bind-dynamic when no interfaces are configured

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/dnsmasq.conf.j2
@@ -1,7 +1,11 @@
 {% for interface in _dnsmasq_interfaces %}
 interface={{ interface }}
 {% endfor %}
+{% if _dnsmasq_interfaces %}
 bind-interfaces
+{% else %}
+bind-dynamic
+{% endif %}
 {% for dhcp_range in _dnsmasq_dhcp_ranges %}
 dhcp-range={{ dhcp_range }}
 {% endfor %}


### PR DESCRIPTION
When _dnsmasq_interfaces is empty, use bind-dynamic instead of bind-interfaces to allow dnsmasq to listen on all interfaces dynamically.