### PR TITLE
dnsdist: add support for network host mode

### DIFF
--- a/roles/dnsdist/defaults/main.yml
+++ b/roles/dnsdist/defaults/main.yml
@@ -22,6 +22,7 @@ dnsdist_configuration_directory: /opt/dnsdist/configuration
 dnsdist_docker_compose_directory: /opt/dnsdist
 
 dnsdist_network: 172.31.101.80/28
+dnsdist_network_mode: bridge
 dnsdist_service_name: "docker-compose@dnsdist"
 
 dnsdist_container_name: dnsdist

--- a/roles/dnsdist/templates/dnsdist.conf.j2
+++ b/roles/dnsdist/templates/dnsdist.conf.j2
@@ -1,4 +1,10 @@
+{% if dnsdist_network_mode == "host" %}
+{% for host in dnsdist_hosts %}
+addLocal('{{ host | ansible.utils.ipwrap }}:{{ dnsdist_port }}')
+{% endfor %}
+{% else %}
 addLocal('0.0.0.0:53')
+{% endif %}
 setACL({'0.0.0.0/0', '::/0'})
 
 {% for server in dnsdist_servers %}

--- a/roles/dnsdist/templates/docker-compose.yml.j2
+++ b/roles/dnsdist/templates/docker-compose.yml.j2
@@ -5,15 +5,20 @@ services:
     container_name: "{{ dnsdist_container_name }}"
     restart: unless-stopped
     command: ["--disable-syslog", "--uid", "dnsdist", "--gid", "dnsdist", "--verbose", "--supervised"]
+{% if dnsdist_network_mode == "host" %}
+    network_mode: host
+{% else %}
     ports:
 {% for host in dnsdist_hosts %}
       - "{{ host | ansible.utils.ipwrap }}:{{ dnsdist_port }}:53"
       - "{{ host | ansible.utils.ipwrap }}:{{ dnsdist_port }}:53/udp"
 {% endfor %}
+{% endif %}
     volumes:
       - "/etc/hosts:/etc/hosts:ro"
       - "{{ dnsdist_configuration_directory }}/dnsdist.conf:/etc/dnsdist/dnsdist.conf:ro"
 
+{% if dnsdist_network_mode != "host" %}
 networks:
   default:
     driver: bridge
@@ -23,3 +28,4 @@ networks:
       driver: default
       config:
         - subnet: {{ dnsdist_network }}
+{% endif %}


### PR DESCRIPTION
Allow dnsdist to bind directly to a specific IP address and port without relying on Docker bridge networking by setting dnsdist_network_mode to "host".

AI-assisted: Claude Code