### PR TITLE
add ECO:DIGIT 'leaf' ansible role

### DIFF
--- a/roles/ecodigit_leaf/README.md
+++ b/roles/ecodigit_leaf/README.md
@@ -1,0 +1,13 @@
+LEAF stands for '**L**ifecycle-based **E**nvironmental **A**ssessment of **F**ootprints' :leaves:
+
+This is a project developed by the OpenSource Business Alliance (OSBA) under the ECO:DIGIT umbrella. To read more about it, please visit their website:
+
+  - https://ecodigit.de/en/home
+
+Other open source projects developed by the ECO:DIGIT team can be found on their GitHub profile:
+
+  - https://github.com/eco-digit
+
+---
+
+> The role here aims to deploy `leaf` as a Docker container on top of an OpenStack infrastructure using OSISM.

--- a/roles/ecodigit_leaf/defaults/main.yml
+++ b/roles/ecodigit_leaf/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+##########################
+# operator
+
+operator_user: "dragon"
+operator_group: "{{ operator_user }}"
+
+##########################
+# docker
+
+docker_network_mtu: 1500
+docker_network_leaf: "172.32.102.0/29"
+docker_registry_leaf: "ghcr.io"
+
+##########################
+# leaf config template
+
+leaf_config_port: 9010
+leaf_config_prometheus_url: "{{ prometheus_internal_endpoint }}"        # https://github.com/osism/defaults/blob/main/all/001-kolla-defaults.yml
+leaf_config_prometheus_user: "{{ prometheus_user | default('admin') }}"
+leaf_config_prometheus_pass: "{{ prometheus_pass | default('') }}"
+
+##########################
+# leaf
+
+leaf_configuration_directory: "/opt/leaf/configuration"
+leaf_container_name: "leaf"
+leaf_container_privileged: false
+leaf_docker_compose_directory: "/opt/leaf"
+leaf_exporter: "prometheus"
+leaf_flags: "{{ leaf_flags_defaults + leaf_flags_extra }}"
+leaf_flags_defaults: "--config /etc/leaf/config.yaml"
+leaf_flags_extras:
+leaf_host: "0.0.0.0"
+leaf_image: "{{ leaf_repository }}:{{ leaf_tag }}"
+leaf_kubeconfig_directory: "/opt/leaf/kubeconfig"
+leaf_port: "{{ leaf_config_port | default('9010') }}"
+leaf_port_container: "{{ leaf_config_port }}"
+leaf_repository: "{{ docker_registry_leaf }}/eco-digit/leaf"
+leaf_service_name: "docker-compose@leaf"
+leaf_share_pids_with_host: false
+leaf_tag: "1.0.0"

--- a/roles/ecodigit_leaf/handlers/main.yml
+++ b/roles/ecodigit_leaf/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart leaf service
+  become: true
+  ansible.builtin.service:
+    name: "{{ leaf_service_name }}"
+    state: restarted
+  register: result
+  until: result["status"]["ActiveState"] == "active"
+  retries: 10
+  delay: 20

--- a/roles/ecodigit_leaf/meta/main.yml
+++ b/roles/ecodigit_leaf/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: Vinícius Zavam
+  description: Role osism.services.leaf
+  company: OSBA ECO:DIGIT
+  license: Apache License 2.0
+  min_ansible_version: 2.16.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+    - name: Debian
+      versions:
+        - bookworm
+    - name: EL
+      versions:
+        - "9"
+  galaxy_tags:
+    - osism
+    - system
+dependencies: []

--- a/roles/ecodigit_leaf/tasks/config.yml
+++ b/roles/ecodigit_leaf/tasks/config.yml
@@ -1,0 +1,22 @@
+---
+- name: Create required directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0750
+  loop:
+    - "{{ leaf_configuration_directory }}"
+    - "{{ leaf_docker_compose_directory }}"
+    - "{{ leaf_kubeconfig_directory }}"
+
+- name: Copy configuration file
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ leaf_configuration_directory }}/config.yaml"
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0640
+  notify: Restart leaf service

--- a/roles/ecodigit_leaf/tasks/main.yml
+++ b/roles/ecodigit_leaf/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Include config tasks
+  ansible.builtin.include_tasks: config.yml
+  tags: config
+
+- name: Include service tasks
+  ansible.builtin.include_tasks: service.yml
+  tags: service

--- a/roles/ecodigit_leaf/tasks/service.yml
+++ b/roles/ecodigit_leaf/tasks/service.yml
@@ -1,0 +1,20 @@
+---
+- name: Copy docker-compose.yml file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ leaf_docker_compose_directory }}/docker-compose.yml"
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: 0640
+  notify: Restart leaf service
+
+- name: Manage leaf service
+  become: true
+  ansible.builtin.service:
+    name: "{{ leaf_service_name }}"
+    state: started
+    enabled: true
+  register: result
+  until: result["status"]["ActiveState"] == "active"
+  retries: 10
+  delay: 20

--- a/roles/ecodigit_leaf/templates/config.yaml.j2
+++ b/roles/ecodigit_leaf/templates/config.yaml.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+---
+prometheus:
+  url: "{{ leaf_config_prometheus_url }}"
+  username: "{{ leaf_config_prometheus_user }}"
+  password: "{{ leaf_config_prometheus_pass }}"

--- a/roles/ecodigit_leaf/templates/docker-compose.yml.j2
+++ b/roles/ecodigit_leaf/templates/docker-compose.yml.j2
@@ -1,0 +1,42 @@
+---
+services:
+  leaf:
+    container_name: "{{ leaf_container_name }}"
+    entrypoint: leaf {{ leaf_flags|join(" ") }}
+    image: "{{ leaf_image }}"
+    privileged: {{ leaf_container_privileged }}
+    restart: unless-stopped
+{% if leaf_share_pids_with_host %}
+    pid: host
+{% endif %}
+    ports:
+      - "{{ leaf_host | ansible.utils.ipwrap }}:{{ leaf_port }}:{{ leaf_port_container }}/tcp"
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+      - type: bind
+        source: "{{ leaf_configuration_directory }}"
+        target: /etc/leaf
+        read_only: true
+      - type: bind
+        source: "{{ leaf_kubeconfig_directory }}"
+        target: /host/kube
+        read_only: true
+    command:
+      - --config /etc/leaf/config.yaml
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: {{ docker_network_mtu }}
+    ipam:
+      driver: default
+      config:
+        - subnet: {{ docker_network_leaf }}


### PR DESCRIPTION
by adding these changes, we:
- add a new role into the OSISM collection;
- would be able to deploy ECO:DIGIT LEAF via OSISM;
- create a service to get ecological (environ.) metrics of the infrastructure;
- extend prometheus exporters available on the infrastructure.

> this is currently a DRAFT, as the `leaf` repository is set as **private** still.

LEAF stands for '**L**ifecycle-based **E**nvironmental **A**ssessment of **F**ootprints' :leaves:

This is a project developed by the OpenSource Business Alliance (OSBA) under the ECO:DIGIT umbrella. To read more about it, please visit their website:

  - https://ecodigit.de/en/home

Other open source projects developed by the ECO:DIGIT team can be found on their GitHub profile:

  - https://github.com/eco-digit

---

> The role here aims to deploy `leaf` as a Docker container on top of an OpenStack infrastructure using OSISM.