### PR TITLE
Split service start and active-state wait into separate tasks

### DIFF
--- a/roles/adminer/handlers/main.yml
+++ b/roles/adminer/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart adminer service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ adminer_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until adminer service is active
+
+- name: Wait until adminer service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ adminer_service_name }}"
+  register: _adminer_is_active
+  changed_when: false
+  failed_when: false
+  until: _adminer_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/adminer/tasks/main.yml
+++ b/roles/adminer/tasks/main.yml
@@ -21,11 +21,18 @@
 
 - name: Manage adminer service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ adminer_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until adminer service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ adminer_service_name }}"
+  register: _adminer_is_active
+  changed_when: false
+  failed_when: false
+  until: _adminer_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/cephclient/handlers/main.yml
+++ b/roles/cephclient/handlers/main.yml
@@ -1,11 +1,20 @@
 ---
 - name: Restart cephclient service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ cephclient_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify:
+    - Wait until cephclient service is active
+
+- name: Wait until cephclient service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ cephclient_service_name }}"
+  register: _cephclient_is_active
+  changed_when: false
+  failed_when: false
+  until: _cephclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
   notify:

--- a/roles/cephclient/handlers/main.yml
+++ b/roles/cephclient/handlers/main.yml
@@ -6,6 +6,7 @@
     state: restarted
   notify:
     - Wait until cephclient service is active
+    - Ensure that all containers are up
 
 - name: Wait until cephclient service is active
   become: true
@@ -17,8 +18,6 @@
   until: _cephclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Ensure that all containers are up
 
 - name: Ensure that all containers are up
   ansible.builtin.command:

--- a/roles/cephclient/tasks/container.yml
+++ b/roles/cephclient/tasks/container.yml
@@ -42,12 +42,19 @@
 
 - name: Manage cephclient service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ cephclient_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until cephclient service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ cephclient_service_name }}"
+  register: _cephclient_is_active
+  changed_when: false
+  failed_when: false
+  until: _cephclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
 

--- a/roles/cgit/handlers/main.yml
+++ b/roles/cgit/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart cgit service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ cgit_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until cgit service is active
+
+- name: Wait until cgit service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ cgit_service_name }}"
+  register: _cgit_is_active
+  changed_when: false
+  failed_when: false
+  until: _cgit_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/cgit/tasks/service.yml
+++ b/roles/cgit/tasks/service.yml
@@ -17,11 +17,18 @@
 
 - name: Manage cgit service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ cgit_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until cgit service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ cgit_service_name }}"
+  register: _cgit_is_active
+  changed_when: false
+  failed_when: false
+  until: _cgit_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/dnsdist/handlers/main.yml
+++ b/roles/dnsdist/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart dnsdist service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ dnsdist_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until dnsdist service is active
+
+- name: Wait until dnsdist service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ dnsdist_service_name }}"
+  register: _dnsdist_is_active
+  changed_when: false
+  failed_when: false
+  until: _dnsdist_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/dnsdist/tasks/service.yml
+++ b/roles/dnsdist/tasks/service.yml
@@ -10,11 +10,18 @@
 
 - name: Manage dnsdist service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ dnsdist_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until dnsdist service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ dnsdist_service_name }}"
+  register: _dnsdist_is_active
+  changed_when: false
+  failed_when: false
+  until: _dnsdist_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,15 +1,24 @@
 ---
 - name: Restart dnsmasq service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ dnsmasq_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
-  retries: 10
-  delay: 20
   when:
     - _dnsmasq_service_restart | default(true) | bool
+  notify:
+    - Wait until dnsmasq service is active
+
+- name: Wait until dnsmasq service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ dnsmasq_service_name }}"
+  register: _dnsmasq_is_active
+  changed_when: false
+  failed_when: false
+  until: _dnsmasq_is_active.stdout | trim == "active"
+  retries: 10
+  delay: 20
   notify:
     - Register that dnsmasq service was restarted
 

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -8,6 +8,7 @@
     - _dnsmasq_service_restart | default(true) | bool
   notify:
     - Wait until dnsmasq service is active
+    - Register that dnsmasq service was restarted
 
 - name: Wait until dnsmasq service is active
   become: true
@@ -19,8 +20,6 @@
   until: _dnsmasq_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Register that dnsmasq service was restarted
 
 - name: Register that dnsmasq service was restarted
   ansible.builtin.set_fact:

--- a/roles/dnsmasq/tasks/service.yml
+++ b/roles/dnsmasq/tasks/service.yml
@@ -12,12 +12,19 @@
   block:  # noqa osism-fqcn
     - name: Manage dnsmasq service
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ dnsmasq_service_name }}"
         state: started
         enabled: true
-      register: result
-      until: result["status"]["ActiveState"] == "active"
+
+    - name: Wait until dnsmasq service is active
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ dnsmasq_service_name }}"
+      register: _dnsmasq_is_active
+      changed_when: false
+      failed_when: false
+      until: _dnsmasq_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify: Wait for dnsmasq service to start
@@ -27,7 +34,7 @@
     # service is tried here.
     - name: Stop dnsmasq service
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ dnsmasq_service_name }}"
         state: stopped
 
@@ -40,11 +47,18 @@
     # then in the expected state.
     - name: Start dnsmasq service again
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ dnsmasq_service_name }}"
         state: started
-      register: result
-      until: result["status"]["ActiveState"] == "active"
+
+    - name: Wait until dnsmasq service is active after rescue
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ dnsmasq_service_name }}"
+      register: _dnsmasq_is_active
+      changed_when: false
+      failed_when: false
+      until: _dnsmasq_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify: Register that dnsmasq service was started

--- a/roles/gnmic/handlers/main.yml
+++ b/roles/gnmic/handlers/main.yml
@@ -1,14 +1,23 @@
 ---
 - name: Restart gnmic service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ gnmic_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  when: _gnmic_service_restart | default(true) | bool
+  notify:
+    - Wait until gnmic service is active
+
+- name: Wait until gnmic service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ gnmic_service_name }}"
+  register: _gnmic_is_active
+  changed_when: false
+  failed_when: false
+  until: _gnmic_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  when: _gnmic_service_restart | default(true) | bool
   notify:
     - Register that gnmic service was restarted
 

--- a/roles/gnmic/handlers/main.yml
+++ b/roles/gnmic/handlers/main.yml
@@ -7,6 +7,7 @@
   when: _gnmic_service_restart | default(true) | bool
   notify:
     - Wait until gnmic service is active
+    - Register that gnmic service was restarted
 
 - name: Wait until gnmic service is active
   become: true
@@ -18,8 +19,6 @@
   until: _gnmic_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Register that gnmic service was restarted
 
 - name: Register that gnmic service was restarted
   ansible.builtin.set_fact:

--- a/roles/gnmic/tasks/main.yml
+++ b/roles/gnmic/tasks/main.yml
@@ -43,11 +43,18 @@
 
 - name: Manage gnmic service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ gnmic_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until gnmic service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ gnmic_service_name }}"
+  register: _gnmic_is_active
+  changed_when: false
+  failed_when: false
+  until: _gnmic_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/homer/handlers/main.yml
+++ b/roles/homer/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart homer service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ homer_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until homer service is active
+
+- name: Wait until homer service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ homer_service_name }}"
+  register: _homer_is_active
+  changed_when: false
+  failed_when: false
+  until: _homer_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/homer/tasks/main.yml
+++ b/roles/homer/tasks/main.yml
@@ -43,11 +43,18 @@
 
 - name: Manage homer service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ homer_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until homer service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ homer_service_name }}"
+  register: _homer_is_active
+  changed_when: false
+  failed_when: false
+  until: _homer_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/kepler/handlers/main.yml
+++ b/roles/kepler/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart kepler service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ kepler_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until kepler service is active
+
+- name: Wait until kepler service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ kepler_service_name }}"
+  register: _kepler_is_active
+  changed_when: false
+  failed_when: false
+  until: _kepler_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/kepler/tasks/service.yml
+++ b/roles/kepler/tasks/service.yml
@@ -10,11 +10,18 @@
 
 - name: Manage kepler service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ kepler_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until kepler service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ kepler_service_name }}"
+  register: _kepler_is_active
+  changed_when: false
+  failed_when: false
+  until: _kepler_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/manager/handlers/main.yml
+++ b/roles/manager/handlers/main.yml
@@ -9,6 +9,8 @@
     - _manager_service_restart | default(true) | bool
   notify:
     - Wait until manager service is active
+    - Wait for manager service to start
+    - Register that manager service was restarted
 
 - name: Wait until manager service is active
   become: true
@@ -20,9 +22,6 @@
   until: _manager_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Wait for manager service to start
-    - Register that manager service was restarted
 
 - name: Wait for manager service to start
   ansible.builtin.pause:

--- a/roles/manager/handlers/main.yml
+++ b/roles/manager/handlers/main.yml
@@ -1,16 +1,25 @@
 ---
 - name: Restart manager service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ manager_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
-  retries: 10
-  delay: 20
   when:
     - manager_service_allow_restart | bool
     - _manager_service_restart | default(true) | bool
+  notify:
+    - Wait until manager service is active
+
+- name: Wait until manager service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ manager_service_name }}"
+  register: _manager_is_active
+  changed_when: false
+  failed_when: false
+  until: _manager_is_active.stdout | trim == "active"
+  retries: 10
+  delay: 20
   notify:
     - Wait for manager service to start
     - Register that manager service was restarted

--- a/roles/netbox/tasks/restart-service.yml
+++ b/roles/netbox/tasks/restart-service.yml
@@ -87,11 +87,19 @@
 
     - name: Start netbox service
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ netbox_service_name }}"
         state: started
       register: netbox_service
-      until: netbox_service["status"]["ActiveState"] == "active"
+
+    - name: Wait until netbox service is active
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ netbox_service_name }}"
+      register: _netbox_is_active
+      changed_when: false
+      failed_when: false
+      until: _netbox_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify:

--- a/roles/netbox/tasks/restart-service.yml
+++ b/roles/netbox/tasks/restart-service.yml
@@ -91,6 +91,8 @@
         name: "{{ netbox_service_name }}"
         state: started
       register: netbox_service
+      notify:
+        - Wait for netbox service to start
 
     - name: Wait until netbox service is active
       become: true
@@ -102,8 +104,6 @@
       until: _netbox_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
-      notify:
-        - Wait for netbox service to start
 
 - name: Restart netbox service
   become: true

--- a/roles/netbox/tasks/service.yml
+++ b/roles/netbox/tasks/service.yml
@@ -49,6 +49,7 @@
         enabled: true
         daemon_reload: "{{ netbox_systemd_unit_file.changed }}"
       register: netbox_service
+      notify: Wait for an healthy netbox service
 
     - name: Wait until netbox service is active
       become: true
@@ -60,7 +61,6 @@
       until: _netbox_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
-      notify: Wait for an healthy netbox service
 
   rescue:
     # Compose is not always reliable when starting services. Therefore,

--- a/roles/netbox/tasks/service.yml
+++ b/roles/netbox/tasks/service.yml
@@ -49,7 +49,15 @@
         enabled: true
         daemon_reload: "{{ netbox_systemd_unit_file.changed }}"
       register: netbox_service
-      until: netbox_service["status"]["ActiveState"] == "active"
+
+    - name: Wait until netbox service is active
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ netbox_service_name }}"
+      register: _netbox_is_active
+      changed_when: false
+      failed_when: false
+      until: _netbox_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify: Wait for an healthy netbox service

--- a/roles/nexus/handlers/main.yml
+++ b/roles/nexus/handlers/main.yml
@@ -7,6 +7,8 @@
   when: _nexus_service_restart | default(true) | bool
   notify:
     - Wait until nexus service is active
+    - Wait for nexus service to start
+    - Register that nexus service was restarted
 
 - name: Wait until nexus service is active
   become: true
@@ -18,9 +20,6 @@
   until: _nexus_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Wait for nexus service to start
-    - Register that nexus service was restarted
 
 - name: Wait for nexus service to start
   ansible.builtin.pause:

--- a/roles/nexus/handlers/main.yml
+++ b/roles/nexus/handlers/main.yml
@@ -1,14 +1,23 @@
 ---
 - name: Restart nexus service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ nexus_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  when: _nexus_service_restart | default(true) | bool
+  notify:
+    - Wait until nexus service is active
+
+- name: Wait until nexus service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ nexus_service_name }}"
+  register: _nexus_is_active
+  changed_when: false
+  failed_when: false
+  until: _nexus_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  when: _nexus_service_restart | default(true) | bool
   notify:
     - Wait for nexus service to start
     - Register that nexus service was restarted

--- a/roles/openstackclient/handlers/main.yml
+++ b/roles/openstackclient/handlers/main.yml
@@ -1,11 +1,20 @@
 ---
 - name: Restart openstackclient service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ openstackclient_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify:
+    - Wait until openstackclient service is active
+
+- name: Wait until openstackclient service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ openstackclient_service_name }}"
+  register: _openstackclient_is_active
+  changed_when: false
+  failed_when: false
+  until: _openstackclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
   notify:

--- a/roles/openstackclient/handlers/main.yml
+++ b/roles/openstackclient/handlers/main.yml
@@ -6,6 +6,7 @@
     state: restarted
   notify:
     - Wait until openstackclient service is active
+    - Ensure that all containers are up
 
 - name: Wait until openstackclient service is active
   become: true
@@ -17,8 +18,6 @@
   until: _openstackclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Ensure that all containers are up
 
 - name: Ensure that all containers are up
   ansible.builtin.command:

--- a/roles/openstackclient/tasks/container-Debian-family.yml
+++ b/roles/openstackclient/tasks/container-Debian-family.yml
@@ -23,12 +23,19 @@
 
 - name: Manage openstackclient service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ openstackclient_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until openstackclient service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ openstackclient_service_name }}"
+  register: _openstackclient_is_active
+  changed_when: false
+  failed_when: false
+  until: _openstackclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
 

--- a/roles/openstackclient/tasks/container-RedHat-family.yml
+++ b/roles/openstackclient/tasks/container-RedHat-family.yml
@@ -23,12 +23,19 @@
 
 - name: Manage openstackclient service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ openstackclient_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until openstackclient service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ openstackclient_service_name }}"
+  register: _openstackclient_is_active
+  changed_when: false
+  failed_when: false
+  until: _openstackclient_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
 

--- a/roles/opentelemetry_collector/handlers/main.yml
+++ b/roles/opentelemetry_collector/handlers/main.yml
@@ -6,6 +6,7 @@
     state: restarted
   notify:
     - Wait until opentelemetry-collector service is active
+    - Ensure that all containers are up
 
 - name: Wait until opentelemetry-collector service is active
   become: true
@@ -17,8 +18,6 @@
   until: _opentelemetry_collector_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Ensure that all containers are up
 
 - name: Ensure that all containers are up
   ansible.builtin.command:

--- a/roles/opentelemetry_collector/handlers/main.yml
+++ b/roles/opentelemetry_collector/handlers/main.yml
@@ -1,11 +1,20 @@
 ---
 - name: Restart opentelemetry-collector service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ opentelemetry_collector_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify:
+    - Wait until opentelemetry-collector service is active
+
+- name: Wait until opentelemetry-collector service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ opentelemetry_collector_service_name }}"
+  register: _opentelemetry_collector_is_active
+  changed_when: false
+  failed_when: false
+  until: _opentelemetry_collector_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
   notify:

--- a/roles/opentelemetry_collector/tasks/main.yml
+++ b/roles/opentelemetry_collector/tasks/main.yml
@@ -32,11 +32,18 @@
 
 - name: Manage opentelemetry-collector service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ opentelemetry_collector_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until opentelemetry-collector service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ opentelemetry_collector_service_name }}"
+  register: _opentelemetry_collector_is_active
+  changed_when: false
+  failed_when: false
+  until: _opentelemetry_collector_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/phpmyadmin/handlers/main.yml
+++ b/roles/phpmyadmin/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart phpmyadmin service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ phpmyadmin_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until phpmyadmin service is active
+
+- name: Wait until phpmyadmin service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ phpmyadmin_service_name }}"
+  register: _phpmyadmin_is_active
+  changed_when: false
+  failed_when: false
+  until: _phpmyadmin_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/phpmyadmin/tasks/main.yml
+++ b/roles/phpmyadmin/tasks/main.yml
@@ -28,11 +28,18 @@
 
 - name: Manage phpmyadmin service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ phpmyadmin_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until phpmyadmin service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ phpmyadmin_service_name }}"
+  register: _phpmyadmin_is_active
+  changed_when: false
+  failed_when: false
+  until: _phpmyadmin_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/scaphandre/handlers/main.yml
+++ b/roles/scaphandre/handlers/main.yml
@@ -1,10 +1,18 @@
 ---
 - name: Restart scaphandre service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ scaphandre_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify: Wait until scaphandre service is active
+
+- name: Wait until scaphandre service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ scaphandre_service_name }}"
+  register: _scaphandre_is_active
+  changed_when: false
+  failed_when: false
+  until: _scaphandre_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/scaphandre/tasks/service.yml
+++ b/roles/scaphandre/tasks/service.yml
@@ -10,11 +10,18 @@
 
 - name: Manage scaphandre service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ scaphandre_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until scaphandre service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ scaphandre_service_name }}"
+  register: _scaphandre_is_active
+  changed_when: false
+  failed_when: false
+  until: _scaphandre_is_active.stdout | trim == "active"
   retries: 10
   delay: 20

--- a/roles/squid/handlers/main.yml
+++ b/roles/squid/handlers/main.yml
@@ -1,14 +1,23 @@
 ---
 - name: Restart squid service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ squid_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  when: squid_service_restart|bool
+  notify:
+    - Wait until squid service is active
+
+- name: Wait until squid service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ squid_service_name }}"
+  register: _squid_is_active
+  changed_when: false
+  failed_when: false
+  until: _squid_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  when: squid_service_restart|bool
   notify:
     - Wait for squid service to start
     - Register that squid service was restarted

--- a/roles/squid/handlers/main.yml
+++ b/roles/squid/handlers/main.yml
@@ -7,6 +7,8 @@
   when: squid_service_restart|bool
   notify:
     - Wait until squid service is active
+    - Wait for squid service to start
+    - Register that squid service was restarted
 
 - name: Wait until squid service is active
   become: true
@@ -18,9 +20,6 @@
   until: _squid_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Wait for squid service to start
-    - Register that squid service was restarted
 
 - name: Wait for squid service to start
   ansible.builtin.pause:

--- a/roles/squid/tasks/main.yml
+++ b/roles/squid/tasks/main.yml
@@ -47,12 +47,19 @@
   block:  # noqa osism-fqcn
     - name: Manage squid service
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ squid_service_name }}"
         state: started
         enabled: true
-      register: result
-      until: result["status"]["ActiveState"] == "active"
+
+    - name: Wait until squid service is active
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ squid_service_name }}"
+      register: _squid_is_active
+      changed_when: false
+      failed_when: false
+      until: _squid_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify: Wait for squid service to start
@@ -62,7 +69,7 @@
     # service is tried here.
     - name: Stop squid service
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ squid_service_name }}"
         state: stopped
 
@@ -75,11 +82,18 @@
     # then in the expected state.
     - name: Start squid service again
       become: true
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: "{{ squid_service_name }}"
         state: started
-      register: result
-      until: result["status"]["ActiveState"] == "active"
+
+    - name: Wait until squid service is active after rescue
+      become: true
+      ansible.builtin.command:
+        cmd: "systemctl is-active {{ squid_service_name }}"
+      register: _squid_is_active
+      changed_when: false
+      failed_when: false
+      until: _squid_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
       notify: Register that squid service was started

--- a/roles/squid/tasks/main.yml
+++ b/roles/squid/tasks/main.yml
@@ -51,6 +51,7 @@
         name: "{{ squid_service_name }}"
         state: started
         enabled: true
+      notify: Wait for squid service to start
 
     - name: Wait until squid service is active
       become: true
@@ -62,7 +63,6 @@
       until: _squid_is_active.stdout | trim == "active"
       retries: 10
       delay: 20
-      notify: Wait for squid service to start
   rescue:
     # Compose is not always reliable when starting services. Therefore,
     # in case of an error at startup, another stop and start of the

--- a/roles/stepca/tasks/service.yml
+++ b/roles/stepca/tasks/service.yml
@@ -33,7 +33,15 @@
     enabled: true
     daemon_reload: "{{ stepca_systemd_unit_file.changed }}"
   register: stepca_service
-  until: stepca_service["status"]["ActiveState"] == "active"
+
+- name: Wait until stepca service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ stepca_service_name }}"
+  register: _stepca_is_active
+  changed_when: false
+  failed_when: false
+  until: _stepca_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
 

--- a/roles/substation/handlers/main.yml
+++ b/roles/substation/handlers/main.yml
@@ -6,6 +6,7 @@
     state: restarted
   notify:
     - Wait until substation service is active
+    - Ensure that all containers are up
 
 - name: Wait until substation service is active
   become: true
@@ -17,8 +18,6 @@
   until: _substation_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
-  notify:
-    - Ensure that all containers are up
 
 - name: Ensure that all containers are up
   ansible.builtin.command:

--- a/roles/substation/handlers/main.yml
+++ b/roles/substation/handlers/main.yml
@@ -1,11 +1,20 @@
 ---
 - name: Restart substation service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ substation_service_name }}"
     state: restarted
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+  notify:
+    - Wait until substation service is active
+
+- name: Wait until substation service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ substation_service_name }}"
+  register: _substation_is_active
+  changed_when: false
+  failed_when: false
+  until: _substation_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
   notify:

--- a/roles/substation/tasks/main.yml
+++ b/roles/substation/tasks/main.yml
@@ -32,12 +32,19 @@
 
 - name: Manage substation service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ substation_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until substation service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ substation_service_name }}"
+  register: _substation_is_active
+  changed_when: false
+  failed_when: false
+  until: _substation_is_active.stdout | trim == "active"
   retries: 10
   delay: 20
 

--- a/roles/thanos_sidecar/tasks/service.yml
+++ b/roles/thanos_sidecar/tasks/service.yml
@@ -10,11 +10,18 @@
 
 - name: Manage thanos_sidecar service
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ thanos_sidecar_service_name }}"
     state: started
     enabled: true
-  register: result
-  until: result["status"]["ActiveState"] == "active"
+
+- name: Wait until thanos_sidecar service is active
+  become: true
+  ansible.builtin.command:
+    cmd: "systemctl is-active {{ thanos_sidecar_service_name }}"
+  register: _thanos_sidecar_is_active
+  changed_when: false
+  failed_when: false
+  until: _thanos_sidecar_is_active.stdout | trim == "active"
   retries: 2
   delay: 120


### PR DESCRIPTION
The generic ansible.builtin.service module does not always populate the status dict with ActiveState, which made result["status"]["ActiveState"] fail with "'dict object' has no attribute 'status'". Switch to ansible.builtin.systemd_service for the start/restart and add a dedicated wait task using systemctl is-active so the until-loop actually observes the activating -> active transition.

AI-assisted: Claude Code