### PR TITLE
wireguard: enable IP forwarding and MASQUERADE for gateway mode

### DIFF
--- a/molecule/delegated/tests/wireguard.py
+++ b/molecule/delegated/tests/wireguard.py
@@ -44,6 +44,17 @@ def test_client_config_files(host):
         assert "AllowedIPs =" in config_file.content_string
 
 
+def test_gateway_forwarding(host):
+    with host.sudo():
+        ip_forward = host.run("sysctl -n net.ipv4.ip_forward")
+        assert ip_forward.rc == 0
+        assert ip_forward.stdout.strip() == "1", "IP forwarding must be enabled for gateway mode"
+
+        masquerade = host.run("iptables -t nat -L POSTROUTING -n")
+        assert masquerade.rc == 0
+        assert "MASQUERADE" in masquerade.stdout, "MASQUERADE rule required for gateway routing"
+
+
 @pytest.mark.parametrize("interface", ["wg0"])
 def test_wireguard_functionality(host, interface):
     with host.sudo():

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -8,3 +8,4 @@ wireguard_endpoint: "{{ wireguard_server_public_address }}:{{ wireguard_listen_p
 wireguard_create_client_config: false
 wireguard_client_allowed_ips: "192.168.16.0/20,172.31.252.0/23,10.43.0.0/16,192.168.112.0/20,192.168.128.0/20"
 wireguard_dns: ""
+wireguard_outbound_interface: "{{ ansible_default_ipv4.interface }}"

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -2,8 +2,8 @@
 Address = {{ wireguard_server_address }}
 ListenPort = {{ wireguard_listen_port }}
 PrivateKey = {{ wireguard_private_key_server['content']|b64decode }}
-PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT
-PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT
+PostUp   = sysctl -w net.ipv4.ip_forward=1; iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o {{ wireguard_outbound_interface }} -j MASQUERADE
+PostDown = iptables -t nat -D POSTROUTING -o {{ wireguard_outbound_interface }} -j MASQUERADE; iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT
 {% for user in wireguard_users %}
 
 [Peer]


### PR DESCRIPTION
## Summary

- Add `sysctl -w net.ipv4.ip_forward=1` and `iptables -t nat -A POSTROUTING -o ... -j MASQUERADE` to the WireGuard role's `PostUp`, and the corresponding `PostDown` cleanup
- Add `wireguard_outbound_interface` variable (default: `ansible_default_ipv4.interface`) to identify the interface for MASQUERADE
- Add `test_gateway_forwarding` molecule test verifying ip_forward and MASQUERADE are in effect after the role runs

## Background

The WireGuard role is deployed on the testbed manager as a gateway: clients connect via WireGuard and traffic to `192.168.16.0/20` (the testbed management network, including `api.testbed.osism.xyz` at `192.168.16.254`) is forwarded through the manager's primary interface.

Two settings were missing:

1. **ip_forward** — without it the kernel silently drops forwarded packets
2. **MASQUERADE** — without it forwarded packets leave the manager with the client's WireGuard IP (`192.168.48.x`) as source, which is not in the manager's Neutron port `allowed_address_pairs` and is dropped by port security

## Scope

The change applies to every node in the `wireguard` host group. Nodes using the role for peer-to-peer VPN without gateway routing will also get ip_forward enabled and a MASQUERADE rule on their default interface. Both are harmless in that context but are broader than strictly necessary.

ip_forward is not restored to 0 in PostDown — this is intentional and standard practice for WireGuard gateways.

## Test plan

- [ ] Molecule test `test_gateway_forwarding` passes (checks ip_forward=1 and MASQUERADE present)
- [ ] Verified end-to-end on regiocloud testbed: WireGuard client on testbed-node-0 connects to manager, pings testbed-node-1 through tunnel — 0% packet loss

**Known limitation:** the molecule MASQUERADE assertion can pass vacuously on CI runners where Docker is running (Docker installs its own MASQUERADE rules). The ip_forward assertion is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)