### PR TITLE
wireguard: add MASQUERADE for gateway mode

### DIFF
--- a/molecule/delegated/prepare/wireguard.yml
+++ b/molecule/delegated/prepare/wireguard.yml
@@ -10,3 +10,10 @@
   ansible.builtin.user:
     name: runner
     group: docker
+
+- name: Enable IP forwarding
+  become: true
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    state: present

--- a/molecule/delegated/tests/wireguard.py
+++ b/molecule/delegated/tests/wireguard.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from .util.util import get_ansible, get_variable
@@ -42,6 +44,41 @@ def test_client_config_files(host):
         assert config_file.group == user
         assert config_file.mode == 0o600
         assert "AllowedIPs =" in config_file.content_string
+
+
+def test_gateway_forwarding(host):
+    with host.sudo("root"):
+        postup_line = host.run(
+            r"grep -oP 'PostUp\s*=\s*\K.+' /etc/wireguard/wg0.conf"
+        ).stdout.strip()
+
+    postrouting_m = re.search(
+        r"iptables\s+-t\s+nat\s+-A\s+POSTROUTING\s+(.*?)(?:;|$)", postup_line
+    )
+    assert postrouting_m, f"No POSTROUTING rule found in PostUp: {postup_line!r}"
+    postrouting_args = postrouting_m.group(1)
+
+    net_m = re.search(r"-s\s+(\S+)", postrouting_args)
+    if_m = re.search(r"-o\s+(\S+)", postrouting_args)
+    assert (
+        net_m and if_m
+    ), f"Could not parse -s/-o from POSTROUTING args: {postrouting_args!r}"
+    client_network = net_m.group(1)
+    outbound_if = if_m.group(1)
+
+    with host.sudo():
+        ip_forward = host.run("sysctl -n net.ipv4.ip_forward")
+        assert ip_forward.rc == 0
+        assert (
+            ip_forward.stdout.strip() == "1"
+        ), "IP forwarding must be enabled for gateway mode"
+
+        check = host.run(
+            f"iptables -t nat -C POSTROUTING -s {client_network} -o {outbound_if} -j MASQUERADE"
+        )
+        assert (
+            check.rc == 0
+        ), f"MASQUERADE rule for {client_network} via {outbound_if} not found in POSTROUTING"
 
 
 @pytest.mark.parametrize("interface", ["wg0"])

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -8,3 +8,5 @@ wireguard_endpoint: "{{ wireguard_server_public_address }}:{{ wireguard_listen_p
 wireguard_create_client_config: false
 wireguard_client_allowed_ips: "192.168.16.0/20,172.31.252.0/23,10.43.0.0/16,192.168.112.0/20,192.168.128.0/20"
 wireguard_dns: ""
+wireguard_outbound_interface: "{{ ansible_default_ipv4.interface }}"
+wireguard_client_network: "{{ wireguard_server_address | regex_replace('\\d+(/\\d+)$', '0\\1') }}"

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -2,8 +2,9 @@
 Address = {{ wireguard_server_address }}
 ListenPort = {{ wireguard_listen_port }}
 PrivateKey = {{ wireguard_private_key_server['content']|b64decode }}
-PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT
-PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT
+PreUp    = sysctl -n net.ipv4.ip_forward | grep -q '^1$' || { echo "wireguard gateway: ip_forward is disabled"; exit 1; }
+PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -s {{ wireguard_client_network }} -o {{ wireguard_outbound_interface }} -j MASQUERADE
+PostDown = iptables -t nat -D POSTROUTING -s {{ wireguard_client_network }} -o {{ wireguard_outbound_interface }} -j MASQUERADE || true; iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT
 {% for user in wireguard_users %}
 
 [Peer]


### PR DESCRIPTION
## Summary

- Adds `PreUp` check that aborts with a clear error if `ip_forward` is disabled, before the interface is created
- Adds scoped MASQUERADE rule on the outbound interface so WireGuard-forwarded packets leave with the manager's own IP — without it Neutron port security drops them (client range `192.168.48.x` is not in `allowed_address_pairs`)
- `PostDown` removes the MASQUERADE rule with `|| true` so upgrading from the old role (which never installed MASQUERADE) does not abort PostDown before the FORWARD cleanups run
- Two new variables: `wireguard_outbound_interface` and `wireguard_client_network`, both with sensible defaults

## Test plan

- [ ] Molecule `test_gateway_forwarding` passes (Zuul CI) — verifies `ip_forward=1` and exact MASQUERADE rule present after role runs; molecule prepare enables `ip_forward` on test nodes
- [ ] Verified end-to-end on regiocloud: WireGuard client connects, pings testbed-node-0 (\`192.168.16.10\`) through the tunnel — 0% packet loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)