### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/roles/dnsmasq/tasks/service.yml
+++ b/roles/dnsmasq/tasks/service.yml
@@ -9,7 +9,7 @@
   notify: Restart dnsmasq service
 
 - name: Ensure that the dnsmasq service is up and running
-  block:  # noqa osism-fqcn
+  block:
     - name: Manage dnsmasq service
       become: true
       ansible.builtin.service:

--- a/roles/docker/tasks/install-docker-Debian-family.yml
+++ b/roles/docker/tasks/install-docker-Debian-family.yml
@@ -115,7 +115,7 @@
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
     allow_downgrade: true
 
-- name: Install python bindings with apt  # noqa: key-order[task], osism-fqcn
+- name: Install python bindings with apt  # noqa: key-order[task]
   become: true
   block:
     - name: Unblock installation of python docker packages
@@ -145,7 +145,7 @@
     - docker_python_install | bool
     - not docker_python_install_from_pip | bool
 
-- name: Install python bindings with pip  # noqa: key-order[task], osism-fqcn
+- name: Install python bindings with pip  # noqa: key-order[task]
   become: true
   block:
 

--- a/roles/docker/tasks/install-docker-RedHat-family.yml
+++ b/roles/docker/tasks/install-docker-RedHat-family.yml
@@ -73,7 +73,7 @@
     - docker_python_install | bool
     - not docker_python_install_from_pip | bool
 
-- name: Install python bindings with pip  # noqa: key-order[task], osism-fqcn
+- name: Install python bindings with pip  # noqa: key-order[task]
   become: true
   block:
     - name: Remove python docker packages (install python bindings from pip)

--- a/roles/frr/tasks/main.yml
+++ b/roles/frr/tasks/main.yml
@@ -55,7 +55,7 @@
 
 - name: Find the correct frr.conf template
   when: frr_config_template is not defined
-  block:  # noqa osism-fqcn
+  block:
     - name: Check for frr.conf file in the configuration repository
       ansible.builtin.stat:
         path: "{{ item }}"

--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -57,7 +57,7 @@
   when: manager_service_manual_start | bool
 
 - name: Ensure that the manager service is up and running
-  block:  # noqa osism-fqcn
+  block:
     - name: Manage manager service
       become: true
       ansible.builtin.systemd_service:

--- a/roles/netbox/tasks/restart-service.yml
+++ b/roles/netbox/tasks/restart-service.yml
@@ -50,7 +50,7 @@
   when:
     - result_container.exists
     - _postgres_version_image is ansible.builtin.version(_postgres_version_container, '>')
-  block:  # noqa osism-fqcn
+  block:
     - name: Stop netbox service
       become: true
       ansible.builtin.service:

--- a/roles/netbox/tasks/service.yml
+++ b/roles/netbox/tasks/service.yml
@@ -40,7 +40,7 @@
     enabled: false
 
 - name: Ensure that the netbox service is up and running
-  block:  # noqa osism-fqcn
+  block:
     - name: Manage netbox service
       become: true
       ansible.builtin.systemd_service:

--- a/roles/netbox/tasks/wait-for-healthy-service.yml
+++ b/roles/netbox/tasks/wait-for-healthy-service.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for an healthy netbox service
-  block:  # noqa osism-fqcn
+  block:
     # The command returns a list of IDs of containers from the service
     # that are currently starting or unhealthy. As long as the list is not empty
     # the service is not in a good state.

--- a/roles/nexus/tasks/initialize.yml
+++ b/roles/nexus/tasks/initialize.yml
@@ -74,7 +74,7 @@
     args:
       docker_bearer_token_realm: "{{ nexus_docker_bearer_token_realm }}"
 
-- name: Process definitions for docker  # noqa: osism-fqcn
+- name: Process definitions for docker
   block:
     - name: Apply defaults to docker proxy repos
       ansible.builtin.set_fact:
@@ -94,7 +94,7 @@
             (nexus_repos_docker_proxy | default([]) | map('combine', {"format": "docker", "type": "proxy"}) | list)
           }}
 
-- name: Process definitions for apt repositories  # noqa: osism-fqcn
+- name: Process definitions for apt repositories
   block:
     - name: Apply defaults to apt proxy repos
       ansible.builtin.set_fact:

--- a/roles/squid/tasks/main.yml
+++ b/roles/squid/tasks/main.yml
@@ -44,7 +44,7 @@
   notify: Restart squid service
 
 - name: Ensure that the squid service is up and running
-  block:  # noqa osism-fqcn
+  block:
     - name: Manage squid service
       become: true
       ansible.builtin.service:


### PR DESCRIPTION
The custom `osism-fqcn` ansible-lint rule previously emitted spurious
violations on `block`/`rescue`/`always` constructs. osism/container-images#902
fixed the rule and the updated `ansible-lint` image has been published, so the
`# noqa osism-fqcn` workarounds on these block constructs are now obsolete.

This removes the obsolete `osism-fqcn` suppressions across 10 task files. All
were block false-positives. Where the annotation was combined with
`key-order[task]`, only the `osism-fqcn` token is dropped and the
`key-order[task]` suppression is preserved.

Part of the osism-fqcn noqa cleanup sweep tracked in osism/issues#1368.

Related-Bug: #1368