### PR TITLE
netbox: start worker on netbox started

### DIFF
--- a/roles/netbox/templates/docker-compose.yml.j2
+++ b/roles/netbox/templates/docker-compose.yml.j2
@@ -84,11 +84,26 @@ services:
 
   netbox-worker:
     <<: *netbox
+    # service_started, not service_healthy: gating the worker on netbox's
+    # health makes `docker compose up` abandon it ("dependency netbox failed
+    # to start: container is unhealthy") whenever netbox flaps unhealthy during
+    # slow startup/migrations, leaving the worker stuck `Created`.
     depends_on:
       netbox:
-        condition: service_healthy
-    entrypoint: /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py
-    command: rqworker
+        condition: service_started
+    # The worker bypasses the image entrypoint, so with service_started it
+    # would start rqworker before migrations exist and spew `UndefinedTable`
+    # errors. Wait until the DB is reachable and fully migrated (`migrate
+    # --check` exits 0 only then), then exec rqworker (so the pgrep
+    # healthcheck still matches the final process).
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        until /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py migrate --check >/dev/null 2>&1; do
+          echo "waiting for netbox database migrations..."
+          sleep 5
+        done
+        exec /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker
     ports: []
     healthcheck:
       test: pgrep -f '/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker'


### PR DESCRIPTION
## What

Gate the rqworker on `netbox` `condition: service_started` instead of
`service_healthy`, and wait for DB migrations before starting rqworker.

## Why — root cause

`ansible-collection-services-molecule-netbox` has been a chronic ~70% flake
(`netbox-netbox-worker-1` never becomes healthy). Confirmed via a CI
systemd-journal capture of the netbox unit: the unit brings the stack up
with attached `docker compose up`, which waits on the worker's
`depends_on: netbox service_healthy`. When netbox's `curl /login`
healthcheck flaps to `unhealthy` during slow DB migrations (exceeding even
the 240s `start_period` on the CI tail), compose declares *"dependency
netbox failed to start: container is unhealthy"*, abandons the worker
(left `Created`) and exits. netbox goes healthy moments later, but compose
has already exited — so the worker is never started.

## Fix

- `service_started` removes the health gate, so compose never waits on (or
  abandons over) netbox's health.
- The worker overrides the image entrypoint to run `manage.py rqworker`
  directly, bypassing the image's DB-wait — so with `service_started`
  alone it would start before migrations and log ~80
  `UndefinedTable: relation "core_job" does not exist` errors. It now waits
  until `manage.py migrate --check` succeeds (DB reachable and fully
  migrated), then `exec`s rqworker (so the `pgrep` healthcheck still
  matches the final process).

## Validation

Validated on draft #2090 (which carries the container-log + journal
instrumentation that pinned the root cause): **10/10 node-samples clean** —
worker `running`, zero rqworker DB errors; the worker waits ~65s for
migrations then starts rqworker cleanly. The abandon is now structurally
impossible (the worker no longer gates on netbox health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)