### PR TITLE
molecule: assert traefik API, not UI HTML string

### DIFF
--- a/molecule/delegated/tests/traefik.py
+++ b/molecule/delegated/tests/traefik.py
@@ -113,5 +113,9 @@ def test_function(host):
     assert result.rc == 0
     assert result.stdout.strip() == "200"
 
-    result = host.run(f"curl {url} | grep -i 'Traefik UI'")
+    # Check the Traefik API responds; stable across versions, unlike the
+    # dashboard HTML.
+    api_url = f"{service_host}:{service_port}/api/version"
+    result = host.run(f"curl -o /dev/null -w '%{{http_code}}' {api_url}")
     assert result.rc == 0
+    assert result.stdout.strip() == "200"


### PR DESCRIPTION
## What

The molecule traefik verify test (`molecule/delegated/tests/traefik.py`,
`test_function`) checked the dashboard with:

```python
result = host.run(f"curl {url} | grep -i 'Traefik UI'")
assert result.rc == 0
```

`grep` exits 1 (no match) when the dashboard HTML lacks the literal string
`Traefik UI`. Traefik rebuilt the dashboard in **React in v3.5.0** (upstream
commit `f16fff577`); the served page `<title>` is now `Traefik Proxy`, so the
string is gone and this assertion fails on any traefik **≥ v3.5.0** — while the
dashboard itself is healthy (the preceding HTTP `200` check passes).

This replaces the brittle HTML-text grep with a check that the traefik **API**
answers on the same entrypoint (`api.insecure` is enabled and mapped to
`traefik_port`), a stable version-independent contract:

```python
api_url = f"{service_host}:{service_port}/api/version"
result = host.run(f"curl -o /dev/null -w '%{{http_code}}' {api_url}")
assert result.rc == 0
assert result.stdout.strip() == "200"
```

Passes on both v3.4.4 (current default) and v3.7.5, and won't break on future
dashboard UI changes.

## Why

The stale assertion blocks the traefik image bump:

- osism/ansible-collection-services#1964 — *chore(deps): update traefik docker tag to v3.7.5*

Its `ansible-collection-services-molecule-traefik` check fails only on this
test. Example failing build (PR #1964, deploying v3.7.5):
<https://zuul.services.osism.tech/t/osism/build/e61e5b36b88b4e9db31a3b9a0fd99876>
— `tests/traefik.py::test_function` FAILED: `curl …/dashboard/` returns `200`,
then `curl …/dashboard/ | grep -i 'Traefik UI'` returns rc 1.

Once this merges, renovate's #1964 should rebase green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)