### PR TITLE
manager: recreate containers after pulling new images

### DIFF
--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -42,6 +42,7 @@
   community.docker.docker_compose_v2_pull:
     project_src: "{{ manager_docker_compose_directory }}"
   when: manager_pre_pull | bool
+  notify: Restart manager service
 
 - name: "Stop and disable old service {{ manager_old_service_name }}"
   become: true


### PR DESCRIPTION
## Problem

`osism update manager` on a host using a rolling tag (e.g. `latest`) fails in:

```
TASK [osism.services.manager : Execute service manager version check]
```

The freshly pulled images are never applied to the running containers, so the version check reports a MISMATCH and exits 1. Recovery currently requires a manual `sudo systemctl restart manager.service` — and per the issue it can recur on subsequent runs.

## Root cause

The `Pull container images` task in `roles/manager/tasks/service.yml` pulls new images but has no `notify`/`register`. A recreate (`docker compose up -d`, via the `Restart manager service` handler chain) is only triggered when the rendered `docker-compose.yml` changes or the systemd unit changes.

On a `latest` → `latest` update neither trigger fires:

1. `Copy docker-compose.yml` → identical text → no notify.
2. `Pull container images` → pulls the new `latest`; the old image (still backing the running containers) loses its `:latest` tag.
3. `systemd_service: state: started` → already running → `changed=false`.
4. `flush_handlers` → nothing to flush → no recreate.
5. `verify-versions` compares the running image (now a bare digest) against the expected `...:latest` → MISMATCH → `exit 1`.

## Fix

Notify the existing `Restart manager service` handler from the pull task. The notify only fires when the pull actually reports `changed`; handlers flush at the end of `service.yml` (before `verify-versions`), so the containers are recreated *before* the check runs. Duplicate notifies (compose file + pull) still collapse into a single restart, and the handler keeps respecting `manager_service_allow_restart`.

## Note

The same "bare pull without notify" pattern exists in the `netbox` and `stepca` roles; tracked separately (one issue per service) since they have no version-check task that surfaces it today.

Closes #2105