### PR TITLE
netbox: recreate containers after pulling new images

### DIFF
--- a/roles/netbox/tasks/service.yml
+++ b/roles/netbox/tasks/service.yml
@@ -31,6 +31,7 @@
   when: netbox_pre_pull | bool
   retries: 3
   delay: 30
+  notify: Restart netbox service
 
 - name: "Stop and disable old service {{ netbox_old_service_name }}"
   become: true


### PR DESCRIPTION
## Problem

The `Pull container images` task in `roles/netbox/tasks/service.yml` pulls new images but has no `notify`/`register`. A recreate (`docker compose up -d`, via the `Restart netbox service` handler chain) is only triggered when the rendered `docker-compose.yml` changes or the systemd unit changes.

On a rolling-tag update (e.g. `latest` → `latest`) the compose file text is identical and the service is already active, so neither trigger fires — the freshly pulled image is downloaded but the running container keeps the old image (which has lost its `:latest` tag) until the next compose/unit change or a manual `systemctl restart netbox.service`.

## Fix

Notify the existing `Restart netbox service` handler from the pull task:

```yaml
- name: Pull container images
  community.docker.docker_compose_v2_pull:
    project_src: "{{ netbox_docker_compose_directory }}"
  when: netbox_pre_pull | bool
  retries: 3
  delay: 30
  notify: Restart netbox service
```

The notify only fires when the pull actually reports `changed`; the handler chain ends in `service: state: restarted` → systemd `ExecStart=docker compose up --remove-orphans` → containers recreated with the new images. The handler keeps respecting `netbox_service_allow_restart`, and the duplicate notify from `Copy docker-compose.yml` still collapses into a single restart.

This mirrors the manager-role fix in #2106 (root cause #2105).

Closes #2107