### PR TITLE
stepca: recreate containers after pulling new images

### DIFF
--- a/roles/stepca/tasks/service.yml
+++ b/roles/stepca/tasks/service.yml
@@ -24,6 +24,7 @@
   when: stepca_pre_pull | bool
   retries: 3
   delay: 30
+  notify: Restart stepca service
 
 - name: Ensure that the stepca service is up and running
   become: true


### PR DESCRIPTION
## Problem

The `Pull container images` task in `roles/stepca/tasks/service.yml` pulls new images but has no `notify`/`register`. A recreate (`docker compose up -d`, via the `Restart stepca service` handler) is only triggered when the rendered `docker-compose.yml` changes or the systemd unit changes.

On a rolling-tag update (e.g. `latest` → `latest`) the compose file text is identical and the service is already active, so neither trigger fires — the freshly pulled image is downloaded but the running container keeps the old image (which has lost its `:latest` tag) until the next compose/unit change or a manual `systemctl restart stepca.service`.

## Fix

Notify the existing `Restart stepca service` handler from the pull task:

```yaml
- name: Pull container images
  community.docker.docker_compose_v2_pull:
    project_src: "{{ stepca_docker_compose_directory }}"
  when: stepca_pre_pull | bool
  retries: 3
  delay: 30
  notify: Restart stepca service
```

The notify only fires when the pull actually reports `changed`; the handler does `systemd_service: state: restarted` → systemd `ExecStart=docker compose up --remove-orphans` → containers recreated with the new images. The handler keeps respecting `stepca_service_allow_restart`, the duplicate notify from `Copy docker-compose.yml` still collapses into a single restart, and `flush_handlers` at the end of `service.yml` applies the restart before the play continues.

This mirrors the manager-role fix in #2106 (root cause #2105).

Closes #2108