### PR TITLE
netbox: don't restart during initial migration

### DIFF
--- a/roles/netbox/tasks/restart-service.yml
+++ b/roles/netbox/tasks/restart-service.yml
@@ -1,4 +1,24 @@
 ---
+# Never act on the netbox service while its initial database migration is
+# still running. A restart landing mid-migration -- e.g. the redundant restart
+# the docker-compose.yml copy notifies on a first deploy -- interrupts NetBox's
+# squashed-migration recording and leaves the database unrecoverable
+# ("Conflicting migrations detected; multiple leaf nodes ... in dcim"),
+# crash-looping netbox. Block until netbox is healthy (migrations complete)
+# before any stop/restart below.
+- name: Wait for netbox to be healthy before restarting
+  ansible.builtin.shell: |
+    set -o pipefail
+    docker compose --project-directory {{ netbox_docker_compose_directory }} ps --all --format json | \
+      jq '. | select(.State=="created" or .State=="exited" or .Health=="starting" or .Health=="unhealthy") | .Name'
+  args:
+    executable: /bin/bash
+  register: result_pre_restart_healthy
+  retries: 60
+  delay: 10
+  changed_when: false
+  failed_when: result_pre_restart_healthy.stdout | length > 0
+
 - name: Get infos on postgres container
   community.docker.docker_container_info:
     name: netbox-postgres-1


### PR DESCRIPTION
## Problem

A first-time netbox deploy can intermittently leave `netbox-netbox-1`
crash-looping, with the data load failing (*"Failed to establish connection
to netbox"*). The container log shows, on every start:

```
CommandError: Conflicting migrations detected; multiple leaf nodes in the
migration graph: (0002_squashed, 0208_devicerole_uniqueness in dcim).
```

`django_migrations` for `dcim` is stuck partway (observed at `0001…0033`),
and the state is **unrecoverable** without wiping the netbox database.

## Root cause

NetBox v4.3.x ships **squashed** dcim migrations. The role restarts the
service via the `Restart netbox service` handler, notified by the
`Copy docker-compose.yml file` task. On a first deploy that copy always
reports `changed`, so the restart fires right after `Manage netbox service`
starts the stack — **while netbox is still running its initial migration**.

If that restart lands while a squash is recording its replaced rows, the
squash is left half-recorded. Django can then reconcile neither the squash nor
the remaining chain → two leaf nodes → `migrate` aborts on every start →
crash-loop.

It was masked until recently: before the worker-start fix, the netbox phase
**failed** on first run and operators re-ran it; the re-run (compose
unchanged) issued no restart, so the migration completed undisturbed. With
the worker fix the phase passes first-run — exactly when the restart fires.

- osism/ansible-collection-services#2091

## Fix

Gate `restart-service.yml` on a health check: block until no netbox container
is `created`/`exited`/`starting`/`unhealthy` — i.e. until migrations have
completed — before any stop or restart. A legitimate config-update restart on
an already-healthy service passes the gate immediately.

## Validation

Reproduced and validated on a from-scratch comback manager bringup against
`main` (services `v0.20260615.0` — the worker-start fix that unmasks this;
**without** this PR).

**Reproduced the crash-loop.** Recreating the first-deploy trigger (wipe the
netbox DB so the initial migration re-runs, and force `Copy docker-compose.yml`
to report `changed` so it notifies the restart handler) and re-running the
`netbox` phase reproduced it:

```
CommandError: Conflicting migrations detected; multiple leaf nodes in the
migration graph: (0001_squashed_0012, 0020_remove_contactgroupmembership in tenancy).
```

`netbox-netbox-1` crash-looped (40+ restarts); `django_migrations` showed the
half-recorded squash. Note the leaf nodes were in **tenancy**, not dcim — the
corruptible squash is whichever (non-atomic) squash is mid-recording when the
restart lands, not dcim-specific.

**Rate: 1 corrupt in 13 unpatched first-deploys (~8%)** — consistent with the
millisecond-scale window.

**Mechanism proof (independent of the ~8% rate).** Instrumented one unpatched
and one patched (this branch) deploy, correlating docker-event timestamps with
migration-log markers:

| | restart fires | initial migration completes | restart vs. migration |
|---|---|---|---|
| **unpatched** | mid-`dcim.0003_squashed_0130` (~80 ms from the squash log line) | ~5 min later | **before** — inside the window |
| **patched (this PR)** | after migration | first | **after** — gate held it |

In the patched run the new `Wait for netbox to be healthy before restarting`
task blocked **33 retries (~5.5 min)** until netbox was healthy, then allowed
the restart. The fix therefore moves the restart out of the migration window
structurally — the interrupt can no longer occur, regardless of the rare
timing.

Left as **draft** pending a CI/molecule pass (the corruption itself is a narrow
race — a CPU-throttle and timed-kill attempt did not reproduce it on demand;
`dcim.0003_squashed_0130` is atomic and rolls back cleanly). Reviewer input
welcome on whether to instead suppress the redundant first-deploy restart
outright.

Out of scope (separate follow-up): the redundant first-deploy restart itself,
and the always-true quoted-string postgres-version `when:` guard later in this
file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
