### PR TITLE
falco: drop obsolete kmod driver workflow

### DIFF
--- a/molecule/delegated/tests/falco/debian.py
+++ b/molecule/delegated/tests/falco/debian.py
@@ -40,27 +40,6 @@ def test_pkg(host):
     assert package.is_installed
 
 
-def test_kernelmodfile(host):
-    check_ansible_os_family(host)
-
-    f = host.file("/etc/modules-load.d/falco.conf")
-    assert f.exists
-    assert not f.is_directory
-    assert f.mode == 0o644
-    assert f.user == "root"
-    assert f.group == "root"
-    assert f.content_string == "falco"
-
-
-def test_kernelmod(host):
-    check_ansible_os_family(host)
-
-    with host.sudo():
-        loaded_modules = host.check_output("lsmod").splitlines()
-
-    assert any("falco" in line for line in loaded_modules)
-
-
 def test_srv(host):
     check_ansible_os_family(host)
 

--- a/roles/falco/tasks/install-Debian-family.yml
+++ b/roles/falco/tasks/install-Debian-family.yml
@@ -44,52 +44,13 @@
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
   notify: "Restart service {{ falco_service_name }}"
 
-- name: Specify driver type with falcoctl
-  become: true
-  ansible.builtin.command:
-    cmd: "falcoctl driver config --type kmod"
-  notify: "Restart service {{ falco_service_name }}"
-  changed_when: true
-
-- name: Install falco driver
-  become: true
-  ansible.builtin.command:
-    cmd: "falcoctl driver install"
-  changed_when: true
-
-- name: Symlink kernel modules
-  become: true
-  ansible.builtin.shell:
-    cmd: |
-      ln -s /root/.falco/*/x86_64/falco_*.ko /lib/modules/$(uname -r)/falco.ko
-      depmod
-  notify: "Restart service {{ falco_service_name }}"
-  changed_when: true
-
-- name: Check if /var/run/reboot-required exist
-  ansible.builtin.stat:
-    path: /var/run/reboot-required
-  register: result
-
-- name: Print message if /var/run/reboot-required exist
-  ansible.builtin.debug:
-    msg: "Reboot of {{ inventory_hostname }} required to get the latest kernel running"
-  when: result.stat.islnk is defined
-
-- name: Persist falco kernel module via modules-load.d
-  become: true
-  ansible.builtin.copy:
-    content: falco
-    dest: /etc/modules-load.d/falco.conf
-    owner: root
-    group: root
-    mode: 0644
-
-- name: Load falco kernel module
-  become: true
-  community.general.modprobe:
-    name: falco
-    state: present
+# No kernel module is built or loaded here: the role runs
+# falco-modern-bpf.service, which uses the modern eBPF probe (CO-RE, shipped in
+# the falco package) and needs no driver build. The previous kmod workflow
+# (falcoctl driver config/install, .ko symlink, modules-load.d, modprobe) was
+# left over from the pre-#1749 falco-kmod service and only broke installs:
+# falcoctl driver install fails on any Debian host lacking a prebuilt .ko and
+# without dkms to compile one.
 
 - name: "Manage service {{ falco_service_name }}"
   become: true


### PR DESCRIPTION
## What

Removes the obsolete kmod driver workflow from the falco role's Debian-family install path (`roles/falco/tasks/install-Debian-family.yml`) and the matching molecule assertions.

## Why

Since #1749 the role runs `falco-modern-bpf.service`, which uses the modern eBPF probe (CO-RE, built into the falco package) and needs no kernel module. The install path nonetheless still ran the pre-#1749 kmod workflow: `falcoctl driver config --type kmod`, `falcoctl driver install`, the `.ko` symlink, `modules-load.d` persistence, and `modprobe`.

This file is the **Debian-family** path, so it runs on both Debian and Ubuntu (`ansible_os_family` is `Debian` for Ubuntu; there is no Ubuntu-specific task file).

`falcoctl driver install` fails on any Debian-family host with no prebuilt `.ko` for its running kernel — it 404s on the download and the compile fallback dies because `dkms` is not installed. A failed command task aborts the play, so applying the role never completes (converge fails before the molecule tests run).

- molecule-falco check red on **debian-bookworm** on every run since 2025-12-01
- ubuntu-noble passed only because a prebuilt `.ko` happened to exist for its runner kernel
- any **Ubuntu** host on a kernel falco has not published a driver for (HWE, newer point releases, custom kernels) would fail identically — a latent failure on our usual target OS

## How

This is a fix to the install path, not a silenced test. With the kmod tasks gone the role applies cleanly on both Debian and Ubuntu, and the modern-bpf service it was already configured to use comes up with no driver build. The two removed molecule assertions (`test_kernelmodfile`, `test_kernelmod`) only checked kmod artifacts (`/etc/modules-load.d/falco.conf` and a loaded falco module) that modern eBPF never produces, so they would now fail on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)