### PR TITLE
manager: wire update-manager seed-container path

### DIFF
--- a/molecule/delegated/tests/manager.py
+++ b/molecule/delegated/tests/manager.py
@@ -183,6 +183,10 @@ def test_manager_config(host):
         "ANSIBLE_USER ANSIBLE_ASK_PASS ANSIBLE_BECOME_ASK_PASS ANSIBLE_SSH_ARGS"
         in update_manager_content
     )
+    #   - warn (do not silently ignore) when a caller sets the venv-only
+    #     ANSIBLE_INVENTORY / ANSIBLE_PRIVATE_KEY overrides on the container path
+    assert "caller_set_inventory" in update_manager_content
+    assert "are ignored on the seed-container update path" in update_manager_content
 
 
 def test_max_user_watches_and_instances(host):

--- a/molecule/delegated/tests/manager.py
+++ b/molecule/delegated/tests/manager.py
@@ -163,6 +163,9 @@ def test_manager_config(host):
     #     the vault-encrypted operator key, cannot be read without it)
     assert "ANSIBLE_VAULT_PASSWORD_FILE" in update_manager_content
     assert ".vault_pass" in update_manager_content
+    #   - forward the interactive vault-prompt toggle too (run.sh parity); the
+    #     documented --ask-vault-pass path for a Redis-only manager with no file
+    assert "ANSIBLE_ASK_VAULT_PASS" in update_manager_content
     #   - writable config mount (in-container keypair step writes id_rsa.operator)
     assert "/opt/configuration:ro" not in update_manager_content
     #   - conditional TTY, not a hardcoded -it (breaks non-interactive callers)

--- a/molecule/delegated/tests/manager.py
+++ b/molecule/delegated/tests/manager.py
@@ -153,7 +153,33 @@ def test_manager_config(host):
     # osism-update-manager must abort on error instead of masking a failed
     # update behind a trailing popd / hardcoded exit 0 (exit-code masking bug).
     update_manager = host.file("/usr/local/bin/osism-update-manager")
-    assert "set -euo pipefail" in update_manager.content_string
+    update_manager_content = update_manager.content_string
+    assert "set -euo pipefail" in update_manager_content
+
+    # The CONTAINER=true (seed-container self-update) path must reach parity
+    # with run.sh's SEED_CONTAINER block so it works on a seed-deployed manager
+    # (no local venv). See osism-update-manager-seed-container-unwired.
+    #   - forward the vault password / auto-detect .vault_pass (the play, and
+    #     the vault-encrypted operator key, cannot be read without it)
+    assert "ANSIBLE_VAULT_PASSWORD_FILE" in update_manager_content
+    assert ".vault_pass" in update_manager_content
+    #   - writable config mount (in-container keypair step writes id_rsa.operator)
+    assert "/opt/configuration:ro" not in update_manager_content
+    #   - conditional TTY, not a hardcoded -it (breaks non-interactive callers)
+    assert "[[ -t 0 ]]" in update_manager_content
+    #   - pass extra args through to the container
+    assert '"$PLAYBOOK" "$@"' in update_manager_content
+    #   - default to auto with engine autodetect so a seed-deployed manager
+    #     (no venv) works out of the box; CONTAINER=false forces the venv path
+    assert "CONTAINER=${CONTAINER:-auto}" in update_manager_content
+    assert '"$CONTAINER_ENGINE" info' in update_manager_content
+    #   - forward run.sh's connection/auth vars too (full allowlist parity);
+    #     MANAGER_VERSION / inventory / private key are deliberately not forwarded
+    #     (resolved from the mounted config inside the seed container)
+    assert (
+        "ANSIBLE_USER ANSIBLE_ASK_PASS ANSIBLE_BECOME_ASK_PASS ANSIBLE_SSH_ARGS"
+        in update_manager_content
+    )
 
 
 def test_max_user_watches_and_instances(host):

--- a/roles/manager/templates/wrapper/osism-update-manager.j2
+++ b/roles/manager/templates/wrapper/osism-update-manager.j2
@@ -104,6 +104,14 @@ if [[ $run_in_container == "true" ]]; then
         container_args+=(-e "ANSIBLE_VAULT_PASSWORD_FILE=/opt/configuration/environments/.vault_pass")
     fi
 
+    # Forward the interactive vault-prompt toggle when the caller set it, as
+    # run.sh does. This is the documented mechanism for a Redis-only manager
+    # with no .vault_pass file (upgrade-guide "--ask-vault-pass"); it pairs with
+    # the conditional -t above so the prompt can be answered inside the container.
+    if [[ -n "${ANSIBLE_ASK_VAULT_PASS+x}" ]]; then
+        container_args+=(-e "ANSIBLE_ASK_VAULT_PASS=$ANSIBLE_ASK_VAULT_PASS")
+    fi
+
     # Pass the playbook and any extra ansible-playbook args ("$@", e.g.
     # --ask-vault-pass, --limit) through to the container.
     container_args+=("$CONTAINER_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG" "$PLAYBOOK" "$@")

--- a/roles/manager/templates/wrapper/osism-update-manager.j2
+++ b/roles/manager/templates/wrapper/osism-update-manager.j2
@@ -19,7 +19,8 @@ PLAYBOOK=${PLAYBOOK:-manager}
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python3}
 VENV_PATH=${VENV_PATH:-.venv}
 
-CONTAINER=${CONTAINER:-false}
+CONTAINER=${CONTAINER:-auto}
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 CONTAINER_IMAGE=${CONTAINER_IMAGE:-osism/seed}
 CONTAINER_REGISTRY=${CONTAINER_REGISTRY:-registry.osism.tech}
 CONTAINER_TAG=${CONTAINER_TAG:-latest}
@@ -29,8 +30,85 @@ if [[ $(whoami) != "{{ operator_user }}" ]]; then
     exit 1
 fi
 
-if [[ $CONTAINER == "true" ]]; then
-    exec docker run --rm -v $CONFIGURATION_DIRECTORY:/opt/configuration:ro -it $CONTAINER_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG $PLAYBOOK
+# Decide whether to run the update inside the osism/seed container. Mirrors
+# run.sh's SEED_CONTAINER selector:
+#   auto  (default) use the container when a container engine is available --
+#                   which on a manager is effectively always, as it hosts the
+#                   control plane in containers; otherwise fall back to the
+#                   local-venv path below
+#   true            require the container (error if the engine is missing)
+#   false           force the local-venv path
+# A seed-deployed manager has no local venv, so auto keeps the documented
+# update working there out of the box; CONTAINER=false restores the old
+# venv-only behaviour for a self-bootstrapped manager.
+run_in_container=false
+case "$CONTAINER" in
+    false)
+        ;;
+    true)
+        if ! command -v "$CONTAINER_ENGINE" >/dev/null 2>&1; then
+            echo >&2 "ERROR: CONTAINER=true but container engine '$CONTAINER_ENGINE' not found on PATH"
+            exit 1
+        fi
+        run_in_container=true
+        ;;
+    auto)
+        if command -v "$CONTAINER_ENGINE" >/dev/null 2>&1 && "$CONTAINER_ENGINE" info >/dev/null 2>&1; then
+            run_in_container=true
+        fi
+        ;;
+    *)
+        echo >&2 "ERROR: invalid CONTAINER value '$CONTAINER' (expected one of: auto, true, false)"
+        exit 1
+        ;;
+esac
+
+if [[ $run_in_container == "true" ]]; then
+    # Seed-container self-update path. Mirrors the SEED_CONTAINER block of
+    # run.sh (osism/generics): the play runs inside the osism/seed container
+    # with the configuration repository bind-mounted, and the seed container
+    # materializes the (vault-encrypted) operator key into that mount itself --
+    # so the mount must be writable and the vault password must be forwarded.
+    container_args=(run --rm -i)
+
+    # Only request a TTY when stdin is one; the old hardcoded -it broke
+    # non-interactive callers (e.g. orchestration over ssh: "the input device
+    # is not a TTY").
+    if [[ -t 0 ]]; then
+        container_args+=(-t)
+    fi
+
+    # Writable (not :ro) so the in-container keypair step can write id_rsa.operator.
+    container_args+=(-v "$CONFIGURATION_DIRECTORY:/opt/configuration")
+
+    # Forward the connection/auth Ansible vars run.sh forwards, but only when the
+    # caller set them. MANAGER_VERSION is intentionally omitted -- the release is
+    # selected from the mounted configuration.yml, not a possibly-stale env
+    # override. ANSIBLE_INVENTORY and ANSIBLE_PRIVATE_KEY are likewise not
+    # forwarded: the seed-container entrypoint resolves both from the mounted
+    # configuration (hardcoded "-i hosts --private-key id_rsa.operator"), exactly
+    # as run.sh's container path does.
+    for var in ANSIBLE_USER ANSIBLE_ASK_PASS ANSIBLE_BECOME_ASK_PASS ANSIBLE_SSH_ARGS; do
+        if [[ -n "${!var+x}" ]]; then
+            container_args+=(-e "$var=${!var}")
+        fi
+    done
+
+    # Vault: forward an explicitly set password file, otherwise auto-detect the
+    # .vault_pass wrapper shipped in the configuration repository (as run.sh
+    # does). Without this the play cannot decrypt secrets.yml -- and the
+    # operator key itself is vault-encrypted, so it cannot be materialized.
+    if [[ -n "${ANSIBLE_VAULT_PASSWORD_FILE+x}" ]]; then
+        container_args+=(-e "ANSIBLE_VAULT_PASSWORD_FILE=$ANSIBLE_VAULT_PASSWORD_FILE")
+    elif [[ -e "$CONFIGURATION_DIRECTORY/environments/.vault_pass" ]]; then
+        container_args+=(-e "ANSIBLE_VAULT_PASSWORD_FILE=/opt/configuration/environments/.vault_pass")
+    fi
+
+    # Pass the playbook and any extra ansible-playbook args ("$@", e.g.
+    # --ask-vault-pass, --limit) through to the container.
+    container_args+=("$CONTAINER_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG" "$PLAYBOOK" "$@")
+
+    exec "$CONTAINER_ENGINE" "${container_args[@]}"
 fi
 
 if [[ -e /usr/bin/ansible || -e /usr/local/bin/ansible ]]; then

--- a/roles/manager/templates/wrapper/osism-update-manager.j2
+++ b/roles/manager/templates/wrapper/osism-update-manager.j2
@@ -4,6 +4,12 @@
 
 set -euo pipefail
 
+# Record which of the documented venv-path overrides the caller set, before the
+# defaults below apply. The seed-container path cannot honor them and warns
+# instead of silently ignoring them (see the container block).
+caller_set_inventory=${ANSIBLE_INVENTORY+x}
+caller_set_private_key=${ANSIBLE_PRIVATE_KEY+x}
+
 ANSIBLE_COLLECTION_SERVICES_SOURCE=${ANSIBLE_COLLECTION_SERVICES_SOURCE:-git+https://github.com/osism/ansible-collection-services}
 ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY:-{{ configuration_directory }}/inventory}
 ANSIBLE_PLAYBOOKS_MANAGER_SOURCE=${ANSIBLE_PLAYBOOKS_MANAGER_SOURCE:-git+https://github.com/osism/ansible-playbooks-manager}
@@ -69,6 +75,15 @@ if [[ $run_in_container == "true" ]]; then
     # with the configuration repository bind-mounted, and the seed container
     # materializes the (vault-encrypted) operator key into that mount itself --
     # so the mount must be writable and the vault password must be forwarded.
+
+    # The documented venv-path overrides ANSIBLE_INVENTORY / ANSIBLE_PRIVATE_KEY
+    # (CHANGELOG, #1033) cannot be honored here: the seed image hardcodes
+    # "-i hosts --private-key id_rsa.operator". Warn rather than silently ignore
+    # them; CONTAINER=false runs the venv path that honors them.
+    if [[ -n "$caller_set_inventory" || -n "$caller_set_private_key" ]]; then
+        echo >&2 "WARNING: ANSIBLE_INVENTORY/ANSIBLE_PRIVATE_KEY are ignored on the seed-container update path; set CONTAINER=false to use them."
+    fi
+
     container_args=(run --rm -i)
 
     # Only request a TTY when stdin is one; the old hardcoded -it broke


### PR DESCRIPTION
## What

Wire the `osism-update-manager` wrapper's `CONTAINER` path to parity with the
`SEED_CONTAINER` block of `run.sh` (`osism/generics`), so `osism update manager`
works on a manager deployed with the seed container (no local Ansible venv).

## Why

"Update the manager" always runs the same `osism.manager.manager` playbook over
SSH; only the driver differs by deployment topology:

| Topology | Manager state at update time | Driver | Before |
|---|---|---|---|
| Seedless / self-bootstrapped | has a local venv | `osism update manager` → venv path | works |
| Persistent seed (separate VM/workstation) | seed holds config+vault+key | re-run `run.sh manager` from the seed | works |
| **Seed container, seed discarded** | only `/opt/configuration` + `/opt/ansible/secrets/id_rsa.operator` | `osism update manager` → **container path** | **broken** |

The seed container is now a documented (and default) deploy path, but the
wrapper's `CONTAINER=true` path was a pre-seed-container fossil: a bare
`docker run` that bind-mounted the config repo read-only, hardcoded `-it`,
forwarded no vault password, and passed only the playbook name. On a
seed-deployed manager it failed immediately with `Attempting to decrypt but no
vault secrets found` — and could not even materialize the (vault-encrypted)
operator key into the read-only mount.

## How

Bring the container path to `run.sh` `SEED_CONTAINER` parity, confirmed against
the `osism/seed` image entrypoint (`container-images/seed` `files/run.sh`):

- bind-mount the configuration repository **writable** (drop `:ro`) so the
  in-container `osism.manager.keypair` step can write `id_rsa.operator`;
- forward an explicit `ANSIBLE_VAULT_PASSWORD_FILE`, else auto-detect
  `environments/.vault_pass`; also forward `ANSIBLE_ASK_VAULT_PASS` (the env
  form of `--ask-vault-pass`, for a Redis-only manager with no `.vault_pass`);
- request a TTY only when stdin is one (the hardcoded `-it` broke
  non-interactive callers); pass `"$@"` through;
- default `CONTAINER=auto` (was `false`): use the seed container when an engine
  is present, else fall back to the venv path; `CONTAINER=false` forces venv,
  `CONTAINER=true` requires the container; `CONTAINER_ENGINE` selects podman;
- forward the connection/auth env allowlist `run.sh` forwards (`ANSIBLE_USER`,
  `ANSIBLE_ASK_PASS`, `ANSIBLE_BECOME_ASK_PASS`, `ANSIBLE_SSH_ARGS`);
- warn when `CONTAINER=auto` selects the container path but the caller set the
  venv-only `ANSIBLE_INVENTORY` / `ANSIBLE_PRIVATE_KEY` overrides (the seed
  entrypoint hardcodes `-i hosts --private-key id_rsa.operator`), so the
  default flip is not silent.

Each commit carries a molecule assertion pinning its behavior.

`MANAGER_VERSION`, `ANSIBLE_INVENTORY`/`ANSIBLE_PRIVATE_KEY`, and the collection
source/version are intentionally **not** forwarded on the container path —
matching `run.sh`: the release is selected from the mounted `configuration.yml`,
and inventory/key are resolved inside the container.

## Stacked on

- osism/ansible-collection-services#2124

This PR is based on that branch (the exit-0 masking fix is its shared base); it
will retarget to `main` once #2124 merges. Review just the wiring commits here.

## Validation

- Rendered + `bash -n` clean; stubbed-engine smoke covers auto/true/false/invalid
  selection and the vault/TTY/arg cases; molecule assertions added per commit.
- **Live-validated GREEN** on a real seed-container-deployed manager (no
  `python3-venv`): vault decrypt succeeds, the operator key is materialized into
  the writable mount, SSH to `hosts: manager` works, conditional `-t` over
  non-interactive SSH, and the exit code propagates — `Apply role manager
  ok=44 changed=7 failed=0`, all container versions match, `rc 0`.

DocImpact — the upgrade guide needs a matching seed-container update story
(which install path → which update path), drafted in:

- osism/osism.github.io#1009

Its gated commit documents this PR's `CONTAINER=auto` behaviour and should land
with/after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
