### PR TITLE
httpd: switch sonic firmware install to dynamic-url

### DIFF
--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -69,12 +69,15 @@ httpd_ironic_listen_addresses:
 httpd_sonic_ztp_enable: false
 
 httpd_sonic_ztp_hostname: metalbox
-httpd_sonic_ztp_firmware: sonic-broadcom-enterprise-base.bin
 httpd_sonic_ztp_directory: sonic
 
 httpd_sonic_ztp_configdb_prefix: osism_
 httpd_sonic_ztp_configdb_identifier: serial-number
 httpd_sonic_ztp_configdb_suffix: _config_db.json
+
+httpd_sonic_ztp_firmware_prefix: sonic-broadcom-enterprise-base_
+httpd_sonic_ztp_firmware_identifier: serial-number
+httpd_sonic_ztp_firmware_suffix: .bin
 
 httpd_sonic_ztp_authorized_keys: []
 httpd_sonic_ztp_authorized_keys_delete: []

--- a/roles/httpd/templates/ztp.json.j2
+++ b/roles/httpd/templates/ztp.json.j2
@@ -2,7 +2,13 @@
   "ztp": {
     "01-firmware": {
       "install": {
-        "url": "http://{{ httpd_sonic_ztp_hostname }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_firmware }}",
+        "dynamic-url": {
+          "source": {
+            "prefix": "http://{{ httpd_sonic_ztp_hostname }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_firmware_prefix }}",
+            "identifier": "{{ httpd_sonic_ztp_firmware_identifier }}",
+            "suffix": "{{ httpd_sonic_ztp_firmware_suffix }}"
+          }
+        },
         "set-default": true
       },
       "reboot-on-success": true


### PR DESCRIPTION
In order to allow to specify individual firmware images per device, switch the install section in the ztp template to use a dynamic URL, just as we already do for the configuration.

Needed-For: https://github.com/osism/metalbox/issues/170