### PR TITLE
renovate: track and batch role image defaults

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,12 +18,17 @@
     {
       "fileMatch":[
         "^roles\\/adminer\\/defaults\\/main.yml$",
+        "^roles\\/cgit\\/defaults\\/main.yml$",
         "^roles\\/dnsdist\\/defaults\\/main.yml$",
+        "^roles\\/dnsmasq\\/defaults\\/main.yml$",
+        "^roles\\/gnmic\\/defaults\\/main.yml$",
         "^roles\\/homer\\/defaults\\/main.yml$",
         "^roles\\/manager\\/defaults\\/main.yml$",
         "^roles\\/netbox\\/defaults\\/main.yml$",
         "^roles\\/nexus\\/defaults\\/main.yml$",
         "^roles\\/phpmyadmin\\/defaults\\/main.yml$",
+        "^roles\\/scaphandre\\/defaults\\/main.yml$",
+        "^roles\\/stepca\\/defaults\\/main.yml$",
         "^roles\\/traefik\\/defaults\\/main.yml$"
       ],
       "matchStrings":[
@@ -40,6 +45,13 @@
     }
   ],
   "packageRules": [
+    {
+      "description": "Batch role-default image bumps into a single monthly PR. Deploy versions are governed by osism/release base.yml (renovated there on its own cadence); these role defaults are fallbacks, so throttle them to keep PR noise low.",
+      "matchFileNames": ["roles/**/defaults/main.yml"],
+      "matchDatasources": ["docker"],
+      "groupName": "role image defaults",
+      "schedule": ["before 9am on the first day of the month"]
+    },
     {
       "matchDepNames": ["postgres", "pgautoupgrade/pgautoupgrade"],
       "matchPaths": ["roles/netbox/defaults/main.yml"],


### PR DESCRIPTION
## What

Extend the collection's Renovate config to track more role-default image
pins and batch role-default bumps into a single monthly PR.

- Add `cgit`, `dnsmasq`, `gnmic`, `scaphandre`, `stepca` to the
  role-defaults `regexManager` `fileMatch`. Each already carries a
  `# renovate:` annotation that never fired (the role was not listed), so
  its `<x>_tag` pin froze.
- Add a `packageRule` grouping every `roles/**/defaults/main.yml` docker
  bump into one monthly PR (`role image defaults`), which also throttles
  the previously-unbatched existing entries.

## Why

Deploy versions are governed by `osism/release` `base.yml` (Renovate-managed
there on its own cadence). These role defaults are only fallbacks, so they
need just an occasional refresh — but when their annotations don't fire they
freeze and drift behind the release pins, surfacing as `role_shadows`
DORMANT findings in the drift detector. Wiring them in and batching monthly
keeps them current without PR noise.

The dedicated `postgres` group is preserved: this rule precedes it, so
`postgres`/`pgautoupgrade` keep their group and inherit the monthly schedule.

## Notes / follow-ups

- The monthly schedule now also throttles the previously-fast existing
  entries (adminer/traefik/…) — intended, net fewer PRs.
- Not covered here (separate follow-ups): the `*_version`-form roles
  (`opentelemetry_collector`, `frr`) need a sibling `_version: '...'`
  matchString; the `zuul` CI stack is intentionally role-managed.

## Refs

- osism/issues#1397
