### PR TITLE
kepler: pin, mirror, and Renovate-track image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,7 @@
         "^roles\\/dnsmasq\\/defaults\\/main.yml$",
         "^roles\\/gnmic\\/defaults\\/main.yml$",
         "^roles\\/homer\\/defaults\\/main.yml$",
+        "^roles\\/kepler\\/defaults\\/main.yml$",
         "^roles\\/manager\\/defaults\\/main.yml$",
         "^roles\\/netbox\\/defaults\\/main.yml$",
         "^roles\\/nexus\\/defaults\\/main.yml$",

--- a/roles/kepler/defaults/main.yml
+++ b/roles/kepler/defaults/main.yml
@@ -9,7 +9,7 @@ operator_group: "{{ operator_user }}"
 # docker
 
 docker_network_mtu: 1500
-docker_registry_kepler: "quay.io"
+docker_registry_kepler: "registry.osism.tech/quay"
 
 ##########################
 # kepler
@@ -30,4 +30,5 @@ kepler_port_container: "{{ kepler_port }}"
 kepler_repository: "{{ docker_registry_kepler }}/sustainable_computing_io/kepler"
 kepler_service_name: "docker-compose@kepler"
 kepler_share_pids_with_host: true
-kepler_tag: "v0.11.2"
+# renovate: datasource=docker depName=quay.io/sustainable_computing_io/kepler
+kepler_tag: 'v0.11.4'


### PR DESCRIPTION
Make the `kepler` role image properly maintainable, per `osism/issues#1403`. Surfaced by container-image drift detection (`role_unpinned`): pinned only in the role default, no working version automation.

- **Bump + track:** `kepler_tag` `v0.11.2` → `'v0.11.4'` (same post-v0.10.0 architecture; low-risk 0.11.x bump), with the `depName=quay.io/...` Renovate annotation, and add the role to the `renovate.json` role-defaults `fileMatch` so it fires.
- **Mirror:** `docker_registry_kepler` `quay.io` → `registry.osism.tech/quay` (transparent pull-through carrying v0.11.0–v0.11.4), so it stops bypassing the OSISM mirror.

> [!NOTE]
> Stacked on #2133 (role-defaults Renovate batching) — base is `renovate-role-defaults`; rebase onto `main` once that lands.

The release-side `role_unpinned` allowlist entry (marking kepler role-managed) is a companion PR in `osism/release`.

Part of osism/issues#1403.