### PR TITLE
openstackclient,cephclient: track deployed series

### DIFF
--- a/molecule/delegated/tests/cephclient/main.py
+++ b/molecule/delegated/tests/cephclient/main.py
@@ -1,4 +1,4 @@
-from ..util.util import get_ansible, get_variable
+from ..util.util import get_ansible, get_variable, jinja_replacement
 
 testinfra_runner, testinfra_hosts = get_ansible()
 
@@ -6,4 +6,10 @@ testinfra_runner, testinfra_hosts = get_ansible()
 def test_function(host):
     status = host.run("ceph --version")
     assert status.rc == 0
-    assert get_variable(host, "cephclient_version").lower() in status.stdout.lower()
+    # cephclient_version now defaults to "{{ ceph_version }}"; include_vars loads
+    # it unrendered, so resolve it against ceph_version like other templated vars.
+    cephclient_version = jinja_replacement(
+        get_variable(host, "cephclient_version"),
+        {"ceph_version": get_variable(host, "ceph_version")},
+    )
+    assert cephclient_version.lower() in status.stdout.lower()

--- a/molecule/delegated/vars/cephclient.yml
+++ b/molecule/delegated/vars/cephclient.yml
@@ -1,3 +1,8 @@
 ---
 operator_user: zuul
 operator_group: zuul
+
+# In real deployments ceph_version is an environment global (set in the
+# environment's configuration.yml). cephclient_version now defaults to it,
+# so supply a representative value here for the standalone molecule converge.
+ceph_version: reef

--- a/molecule/delegated/vars/openstackclient.yml
+++ b/molecule/delegated/vars/openstackclient.yml
@@ -1,3 +1,8 @@
 ---
 operator_user: zuul
 operator_group: zuul
+
+# In real deployments openstack_version is an environment global (set in the
+# environment's configuration.yml). openstackclient_version now defaults to it,
+# so supply a representative value here for the standalone molecule converge.
+openstack_version: "2025.1"

--- a/roles/cephclient/defaults/main.yml
+++ b/roles/cephclient/defaults/main.yml
@@ -16,7 +16,7 @@ operator_group: "{{ operator_user }}"
 # cephclient
 
 cephclient_install_type: container
-cephclient_version: reef
+cephclient_version: "{{ ceph_version }}"
 
 cephclient_mons: []
 cephclient_keyring: ""

--- a/roles/openstackclient/defaults/main.yml
+++ b/roles/openstackclient/defaults/main.yml
@@ -19,7 +19,7 @@ operator_group: "{{ operator_user }}"
 # openstackclient
 
 openstackclient_install_type: container
-openstackclient_version: "2024.2"
+openstackclient_version: "{{ openstack_version }}"
 
 ##########################
 # container


### PR DESCRIPTION
## Terminology

**"latest" here means `manager_version: latest`** — the rolling osism-ansible **manager image**, as opposed to a pinned release build (`manager_version: <X>`). It is a *separate axis* from the OpenStack/Ceph series (`openstack_version` / `ceph_version`), which the environment sets independently.

## Problem

In `manager_version: latest` deployments the `openstackclient` and `cephclient` **image tags freeze behind the series they run against**: `openstackclient` deploys `2024.2` while the environment's `openstack_version` is `2025.1`. `cephclient` is the same latent case (its role default `reef` only coincidentally matches the current ceph series).

## Root cause

The manager render template resolves the tag as `"{{ openstackclient_version|default(openstack_version) }}"` — designed so `latest` builds fall back to `openstack_version` (the deployed series) while pinned builds inject the release pin. But the role default `openstackclient_version` was introduced in [`bb78ec7c`](https://github.com/osism/ansible-collection-services/commit/bb78ec7c6a305cc528903cd22fba7a693433d1f7) (2020-08), a year **before** that fallback was added ([`126884d`](https://github.com/osism/container-image-osism-ansible/commit/126884da244daa662dd50422b13137268a88ac86) + [`0d8b503`](https://github.com/osism/container-image-osism-ansible/commit/0d8b503ccb3eb0c29a16cb029e842710cdf11265), 2021-07, in `container-image-osism-ansible`). Being always defined, the role default **shadows** the fallback: `|default(openstack_version)` never fires in `latest` mode, so the static role literal governs and drifts.

## Fix

Default the role vars to the environment series instead of a literal:

- `openstackclient_version` → `"{{ openstack_version }}"`
- `cephclient_version` → `"{{ ceph_version }}"`

`latest` builds now track the deployed series dynamically (restoring the intended behaviour). A recent client is safe against supported clouds (microversion negotiation), so tracking the deployed series is the correct posture.

## Why this is safe in both build modes

`openstack_version` / `ceph_version` are set in the environment's `environments/manager/configuration.yml` **only when `manager_version: latest`** (cookiecutter-generated); pinned releases omit them and instead inject `openstackclient_version` / `cephclient_version` from the release train via `render-versions.py`.

| `manager_version` | series vars defined? | governs the tag | role default `"{{ openstack_version }}"` |
|---|---|---|---|
| `latest` | yes (env config) | role default → `openstack_version` | **evaluated, resolves** |
| pinned | no | injected train pin (higher-precedence group_var) | **shadowed, never evaluated** |

So `"{{ openstack_version }}"` is only ever *evaluated* in `latest` mode — exactly where the variable is defined.

`molecule/delegated` supplies `openstack_version` / `ceph_version` in the per-role vars so the standalone converge (which has no manager group_vars) can resolve the new defaults. The cephclient molecule test resolves the now-templated value via `jinja_replacement`, as the cgit/docker/auditd tests already do.

## Companion change

This is the deploy-side half. The image-side half:

- osism/container-images#946 — publishes `openstackclient:latest` from the rolling (master-based) build, so the `openstack_version: latest` selection resolves too (concrete series work with this PR alone).

## Out of scope

`openstackclient`'s Ubuntu Cloud Archive pocket still interpolates the release **number** (`…-updates/{{ openstackclient_version }}`) rather than the codename (UCA uses e.g. `noble-updates/dalmatian`) — a separate, dormant bug on the non-default `install_type: package` path.