### PR TITLE
manager: default ARA DB CONN_MAX_AGE to 0

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -259,6 +259,9 @@ ara_server_traefik: false
 ara_server_host: "{{ ansible_default_ipv4.address | default(ansible_default_ipv6.address, true) }}"
 ara_server_port: 8120
 
+# CONN_MAX_AGE=0: a >0 value leaks DB connections under the gevent worker class
+# (per-request greenlet-local connections are never closed) -> MariaDB exhaustion.
+ara_database_conn_max_age: 0
 ara_threads: 1
 ara_worker_class: gevent
 ara_worker_connections: 1000

--- a/roles/manager/templates/env/ara-server.env.j2
+++ b/roles/manager/templates/env/ara-server.env.j2
@@ -7,7 +7,7 @@ ARA_WORKER_CLASS={{ ara_worker_class }}
 ARA_WORKER_CONNECTIONS={{ ara_worker_connections }}
 ARA_WRITE_LOGIN_REQUIRED=true
 {% if ara_server_database_type == 'mysql' %}
-ARA_DATABASE_CONN_MAX_AGE=120
+ARA_DATABASE_CONN_MAX_AGE={{ ara_database_conn_max_age }}
 ARA_DATABASE_ENGINE=django.db.backends.mysql
 ARA_DATABASE_HOST=mariadb
 ARA_DATABASE_NAME={{ ara_server_mariadb_databasename }}


### PR DESCRIPTION
## Problem

`roles/manager/templates/env/ara-server.env.j2` hardcoded
`ARA_DATABASE_CONN_MAX_AGE=120`. Combined with the manager default
`ara_worker_class: gevent`, this leaks manager MariaDB connections: Django keeps
DB connections in per-request greenlet-local storage and only closes an expired
one at a request boundary in the *same* greenlet — but gunicorn's gevent worker
spawns a fresh greenlet per request, so a connection opened by one request is
never revisited and `CONN_MAX_AGE` never closes it. Each request leaks one
persistent connection over time until MariaDB `max_connections` (151) is
exhausted, after which `ara-server` returns HTTP 500 on **every** request —
surfacing as ARA callback `Failure using method` warnings on every `osism apply`
and an unhealthy `ara-server` container.

The `120` value was introduced following upstream ARA perf advice that assumed
the sync/threaded worker model (where persistent connections are safe and
naturally bounded by worker count):

- #801

## Fix

Make the value a role variable `ara_database_conn_max_age` defaulting to `0`.
With `0`, Django closes the connection at request-end, so no connection outlives
its request-greenlet and concurrent connections stay bounded by in-flight load.
The reuse optimization given up is negligible at ARA's light callback load;
operators running the sync worker class can raise it again via the new variable.

## Validation (live, `latest` full-profile deploy)

Flipped `ARA_DATABASE_CONN_MAX_AGE` 120→0 in the deployed env and recreated
`manager-ara-server-1`:

| metric | before (`120`) | after (`0`) |
|---|---|---|
| idle `ara` DB connections | 151 (all `Sleep`) | 0 |
| under 300-request / 30-concurrent burst | would pin at 151 | steady ~5, back to 0 after |
| `GET /api/v1/plays` (authenticated) | 500 | 200 |
| container health | unhealthy | healthy |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
