### PR TITLE
substation: pin and Renovate-track image

### DIFF
--- a/roles/substation/defaults/main.yml
+++ b/roles/substation/defaults/main.yml
@@ -18,7 +18,8 @@ operator_group: "{{ operator_user }}"
 ##########################
 # substation
 
-substation_version: latest
+# renovate: datasource=docker depName=ghcr.io/cloudnull/substation/substation
+substation_tag: '1774452086'
 
 ##########################
 # container
@@ -27,7 +28,6 @@ substation_configuration_directory: /opt/substation/configuration
 substation_data_directory: /opt/substation/data
 substation_docker_compose_directory: /opt/substation
 
-substation_tag: "{{ substation_version }}"
 substation_image: "{{ docker_registry_substation }}/cloudnull/substation/substation:{{ substation_tag }}"
 
 substation_container_name: substation


### PR DESCRIPTION
Give the `substation` role default a concrete, Renovate-tracked tag matching
the collection's house pattern (as used by `stepca`, `traefik`, etc.).

Replaces `substation_version: latest` (rolling, untracked) with a concrete
`substation_tag: '1774452086'` carrying its own `# renovate:` docker marker,
and drops the now-redundant `substation_version` indirection.

Once wired (companion PRs), the role default is only a fallback — this keeps
that fallback reproducible and version-tracked rather than rolling `latest`.

### Renovate — no special versioning rule needed

Default `docker` versioning tracks the bare-integer epoch tags (verified against
the Renovate versioning source: valid, comparable, mutually compatible; `latest`
ignored). `versioning: loose` is **not** required.

### Related

- osism/issues#1404