### PR TITLE
docker: retry python3-docker deb download on transient failures

### DIFF
--- a/roles/docker/tasks/install-docker-Debian-family.yml
+++ b/roles/docker/tasks/install-docker-Debian-family.yml
@@ -138,6 +138,10 @@
     - name: Install python3 docker package from Debian Sid
       ansible.builtin.apt:
         deb: "{{ docker_python3_package_deb }}"
+      register: result
+      until: result is succeeded
+      retries: 5
+      delay: 10
       when:
         - "ansible_distribution_version is version('24.04', '>=')"
 


### PR DESCRIPTION
## What

Add `register`/`until`/`retries`/`delay` to the `ansible.builtin.apt`
task in the docker role that installs `python3-docker` as a `.deb`
directly from a GitHub URL (`Install python3 docker package from
Debian Sid` in `roles/docker/tasks/install-docker-Debian-family.yml`).
It retries up to 5 times with a 10s delay.

## Why

The identical `apt deb:` construct (same `deb-packaging` URL) has
failed repeatedly in osism/testbed CI as transient GitHub transfer
stalls — read timeouts, urlopen timeouts, TLS handshake timeouts —
where a single stalled connection failed the whole deploy even though
the resource was fine. It was hardened the same way in
osism/testbed#2931; this applies the same fix at the source, in the
docker role itself.

The `until`/`retries` idiom matches what this collection already uses
elsewhere (e.g. service-active waits in cgit, adminer, netbox,
openstackclient).

## Testing

`ansible-lint` (production profile) and `yamllint` pass on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)