### PR TITLE
netbox: fix quoted version guard in restart

### DIFF
--- a/roles/netbox/tasks/restart-service.yml
+++ b/roles/netbox/tasks/restart-service.yml
@@ -127,7 +127,7 @@
     - Wait for netbox service to start
   when:
     - (not result_container.exists or
-       (result_container.exists and "_postgres_version_image is ansible.builtin.version(_postgres_version_container, '>=')"))
+       (result_container.exists and _postgres_version_image is ansible.builtin.version(_postgres_version_container, '>=')))
 
 - name: Register that netbox service was started
   ansible.builtin.set_fact:


### PR DESCRIPTION
The restart guard in `roles/netbox/tasks/restart-service.yml` wrapped its
version test in double quotes, so the inner expression was a **string
literal, never evaluated**:

```yaml
when:
  - (not result_container.exists or
     (result_container.exists and "_postgres_version_image is
      ansible.builtin.version(_postgres_version_container, '>=')"))
```

On ansible-core <= 2.18 a non-empty string is truthy, so the guard was
effectively always true and netbox restarted **unconditionally**; on 2.19 a
non-boolean conditional aborts the task (`Conditionals must have a boolean
result`).

Dropping the inner quotes fixes both problems and restores the intended
semantics: restart only when the container is absent, or the image version
is `>=` the running container's version (no restart on a would-be
downgrade). The absent-container branch short-circuits, so the version
facts (set only when the container exists) are never dereferenced undefined.

⚠️ **Behaviour change**: on the current 11.x pin this makes the restart
conditional where it was previously unconditional — filed as its own PR for
that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)