### PR TITLE
httpd: stringify USER_ID/GROUP_ID env values

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -52,8 +52,8 @@
     name: httpd-data
     image: "{{ httpd_data_image }}"
     env:
-      USER_ID: "{{ httpd_data_uid }}"
-      GROUP_ID: "{{ httpd_data_gid }}"
+      USER_ID: "{{ httpd_data_uid | string }}"
+      GROUP_ID: "{{ httpd_data_gid | string }}"
     volumes:
       - "{{ httpd_data_directory }}:/export"
     state: started


### PR DESCRIPTION
The httpd-data container passes `USER_ID` / `GROUP_ID` as env values
templated from `httpd_data_uid` / `httpd_data_gid`, which default to the
integer facts `ansible_facts.user_uid` / `user_gid`. ansible-core 2.19
rejects non-string env option values (`Non-string value found for env
option. Ambiguous env options must be wrapped in quotes ... Key: USER_ID`),
failing the molecule-httpd job.

Coerce both with `| string` so the env options are unambiguous strings.

Prep for moving `ansible_molecule_ansible_version` to 12.x (ansible-core
2.19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)