### PR TITLE
frr: make maximum-paths configurable

### DIFF
--- a/roles/frr/defaults/main.yml
+++ b/roles/frr/defaults/main.yml
@@ -56,6 +56,14 @@ frr_vrrp_groups: []
 
 frr_incoming_table_external: 254
 
+# Maximum number of ECMP paths installed per BGP address family
+# (maximum-paths). With 0 no maximum-paths statement is written, so the
+# FRR built-in default applies (256 in the Debian and RedHat family
+# packages), which means all available paths are used. Set a value
+# greater than 0 only to limit the number of paths. Not used by the
+# yrzn templates.
+frr_maximum_paths: 0
+
 frr_local_pref:
   - 1000
 
@@ -95,6 +103,9 @@ frr_vtysh_file: "/etc/frr/vtysh.conf"
 frr_daemons_file: "/etc/frr/daemons"
 
 frr_allow_service_restart: true
+
+# YRZN 001 configuration
+frr_yrzn001_maximum_paths: 2
 
 # YRZN Metalbox configuration
 frr_yrzn_metalbox_bmc_loopback: loopback0

--- a/roles/frr/templates/frr_leaf.conf.j2
+++ b/roles/frr/templates/frr_leaf.conf.j2
@@ -42,7 +42,9 @@ router bgp {{ frr_local_as }}
 {% endif %}
   neighbor {{ item.interface }} route-map bgp_out out
 {% endfor %}
-  maximum-paths 2
+{% if frr_maximum_paths | int > 0 %}
+  maximum-paths {{ frr_maximum_paths | int }}
+{% endif %}
  exit-address-family
  !
  address-family ipv6 unicast

--- a/roles/frr/templates/frr_loadbalancer.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer.conf.j2
@@ -54,7 +54,9 @@ router bgp {{ frr_local_as }}
 {% for item in frr_neigh_v6 %}
   no neighbor {{ item.address }} activate
 {% endfor %}
-  maximum-paths 2
+{% if frr_maximum_paths | int > 0 %}
+  maximum-paths {{ frr_maximum_paths | int }}
+{% endif %}
  exit-address-family
  !
  address-family ipv6 unicast

--- a/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
+++ b/roles/frr/templates/frr_loadbalancer_external_uplink.conf.j2
@@ -43,7 +43,9 @@ router bgp {{ frr_local_as }}
   neighbor {{ item.interface }} route-map bgp_in_external in
   neighbor {{ item.interface }} route-map bgp_out_external out
 {% endfor %}
-  maximum-paths 2
+{% if frr_maximum_paths | int > 0 %}
+  maximum-paths {{ frr_maximum_paths | int }}
+{% endif %}
  exit-address-family
  !
  address-family ipv6 unicast

--- a/roles/frr/templates/frr_yrzn001.conf.j2
+++ b/roles/frr/templates/frr_yrzn001.conf.j2
@@ -22,7 +22,7 @@ router bgp {{ frr_local_as }}
   no neighbor switches send-community
   neighbor switches route-map RM-switches-in in
   neighbor switches route-map RM-switches-out out
-  maximum-paths 2
+  maximum-paths {{ frr_yrzn001_maximum_paths }}
  exit-address-family
  !
  address-family ipv6 unicast
@@ -31,7 +31,7 @@ router bgp {{ frr_local_as }}
   neighbor switches activate
   neighbor switches route-map RM-switches-in in
   neighbor switches route-map RM-switches-out out
-  maximum-paths 2
+  maximum-paths {{ frr_yrzn001_maximum_paths }}
  exit-address-family
 
 exit


### PR DESCRIPTION
The generic templates (`frr_leaf`, `frr_loadbalancer` and `frr_loadbalancer_external_uplink`) hardcoded `maximum-paths 2` per BGP address family. With four uplinks FRR then only installs two of the four ECMP paths, which do not necessarily match the paths the switches pick for the return traffic, breaking connections.

- Drop the hardcoded setting from the generic templates. Without an explicit `maximum-paths`, FRR falls back to its built-in default of `multipath_num` (256 in both the Debian and RedHat family packages, independent of the `frr defaults traditional` profile), so all available paths are used.
- The new `frr_maximum_paths` variable (`0` by default) renders the line again when a deployment wants to limit the number of paths. The templates check `| int > 0`, so a value of `0` and non-integer values do not write the statement.
- The yrzn templates keep their previous default of two paths; the hardcoded value in `frr_yrzn001.conf.j2` moves into the new `frr_yrzn001_maximum_paths` variable so it can be overridden like its metalbox and network counterparts.

Fixes #2122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
