### PR TITLE
manager: retry image pull on transient errors

### DIFF
--- a/roles/manager/tasks/service.yml
+++ b/roles/manager/tasks/service.yml
@@ -42,6 +42,8 @@
   community.docker.docker_compose_v2_pull:
     project_src: "{{ manager_docker_compose_directory }}"
   when: manager_pre_pull | bool
+  retries: 3
+  delay: 30
   notify: Restart manager service
 
 - name: "Stop and disable old service {{ manager_old_service_name }}"


### PR DESCRIPTION
## What

Add `retries: 3` / `delay: 30` to the manager role's `Pull container images`
task. Two lines, no behaviour change on the happy path.

## Why

The manager compose file pulls two third-party images straight from Docker Hub
by design: `docker_registry_service` defaults to `docker_registry`
(`index.docker.io`), so `mariadb` and `redis` come from there, while the
OSISM-built images resolve via `docker_registry_ansible` to
`registry.osism.tech`. In a rendered `/opt/manager/docker-compose.yml`, 10 of 12
images come from `registry.osism.tech` and exactly those two from
`index.docker.io/library/`.

Docker Hub is therefore a hard dependency we do not control, and it both
returns transient 5xx and rate limits anonymous pulls. The task had no retry, so
one bad response failed the task and with it the whole manager phase.

Observed on a fresh manager bootstrap:

```
[ERROR]: Task failed: Module failed: Error when processing image
index.docker.io/library/mariadb:11.8.8: Error response from daemon:
Head "https://registry-1.docker.io/v2/library/mariadb/manifests/11.8.8":
received unexpected HTTP status: 502 Bad Gateway
```

Retrying the same pull by hand immediately afterwards succeeded 3/3, so the
error was transient.

Worth noting for anyone triaging a similar report: `docker compose pull` aborts
every image once one of them errors, so the concurrently pulling
`registry.osism.tech` images were additionally reported as `Interrupted`. That
makes the failure look like a broad registry outage when it is a single image.

## This was the only pull site without a retry

| Site | Retry |
|---|---|
| `roles/netbox/tasks/service.yml` (compose pull) | `retries: 3`, `delay: 30` |
| `roles/netbox/tasks/restart-service.yml` (postgres, `docker_image`) | `retries: 3`, `delay: 30` |
| `roles/stepca/tasks/service.yml` (compose pull) | `retries: 3`, `delay: 30` |
| kolla-ansible `service-images-pull` | `retries`/`delay` + `until: result is success` |
| `roles/manager/tasks/service.yml` | **none** |

So this reuses an established pattern rather than introducing one. The task is
now identical to the netbox sibling apart from the service name.

## On the absent `until`

`until` is omitted deliberately, to match the two sibling tasks. It is still
effective, which is worth stating because the Ansible docs say `retries` "is
only used in combination with `until`":

`ansible-core` computes `retries = 1 + max(0, task.retries)` and, when `until`
is unset, falls back to an implicit condition on the task not having failed —
`cond.when = self._task.until or [not result['failed']]` in
`executor/task_executor.py`. This therefore yields four attempts that stop as
soon as the pull succeeds. Verified against ansible-core 2.18, the series
currently pinned.

If reviewers would rather be explicit, adding `register: result` +
`until: result is success` here (and to the two siblings, for consistency) is a
reasonable alternative — I kept the diff minimal instead.

## Risk

Low. On success the task behaves exactly as before. On failure it now takes up
to 90s longer before failing the phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
