### PR TITLE
frr: allow locking the installed package version

### DIFF
--- a/molecule/delegated/tests/frr.py
+++ b/molecule/delegated/tests/frr.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from .util.util import get_ansible, get_variable, jinja_list_concat
@@ -11,6 +13,20 @@ def test_pkg(host):
 
     package = host.package(package_name)
     assert package.is_installed
+
+
+def test_version_lock(host):
+    if not get_variable(host, "frr_version_lock"):
+        pytest.skip("frr_version_lock disabled")
+
+    package_name = get_variable(host, "frr_package_name")
+
+    if host.exists("apt-mark"):
+        assert package_name in host.check_output("apt-mark showhold").split()
+    else:
+        with host.sudo():
+            locked = host.check_output("dnf versionlock list")
+        assert re.search(rf"^{re.escape(package_name)}-[0-9]+:", locked, re.MULTILINE)
 
 
 def test_daemonfile(host):

--- a/roles/frr/defaults/main.yml
+++ b/roles/frr/defaults/main.yml
@@ -4,6 +4,14 @@ frr_service_name: frr
 
 frr_version: "8.1"
 
+# Lock the currently installed frr package version. When enabled, the
+# package is put on hold (apt-mark hold on the Debian family, dnf
+# versionlock on the RedHat family) so that a later apt-get upgrade or
+# dnf upgrade does not upgrade frr. The role itself still applies
+# version changes, the lock is released before the package is installed
+# and set again afterwards. Set this to false to release the lock.
+frr_version_lock: true
+
 frr_sysctl_defaults:
   - name: net.ipv4.ip_forward
     value: 1

--- a/roles/frr/tasks/install-Debian-family.yml
+++ b/roles/frr/tasks/install-Debian-family.yml
@@ -1,4 +1,19 @@
 ---
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+# NOTE: A held package makes apt-get abort as soon as the version has to be
+#       changed, therefore the package is always unlocked before it is
+#       installed.
+- name: Unlock frr package
+  become: true
+  ansible.builtin.dpkg_selections:
+    name: "{{ frr_package_name }}"
+    selection: install
+  when: frr_package_name in ansible_facts.packages
+  tags: molecule-idempotence-notest
+
 - name: Pin frr package version
   become: true
   ansible.builtin.copy:
@@ -15,3 +30,11 @@
     name: "{{ frr_package_name }}"
     state: present
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
+
+- name: Lock frr package
+  become: true
+  ansible.builtin.dpkg_selections:
+    name: "{{ frr_package_name }}"
+    selection: hold
+  when: frr_version_lock | bool
+  tags: molecule-idempotence-notest

--- a/roles/frr/tasks/install-RedHat-family.yml
+++ b/roles/frr/tasks/install-RedHat-family.yml
@@ -6,14 +6,32 @@
     state: present
     lock_timeout: "{{ dnf_lock_timeout | default(300) }}"
 
-- name: Pin frr package version
-  become: true
-  ansible.builtin.command: "dnf versionlock {{ frr_package_name }}"
-  changed_when: false
-
 - name: Install frr package
   become: true
   ansible.builtin.dnf:
     name: "{{ frr_package_name }}"
     state: present
     lock_timeout: "{{ dnf_lock_timeout | default(300) }}"
+
+- name: Get frr versionlock entries
+  become: true
+  ansible.builtin.command: dnf versionlock list
+  register: frr_versionlock
+  changed_when: false
+  check_mode: false
+
+- name: Lock frr package
+  become: true
+  ansible.builtin.command: "dnf versionlock add {{ frr_package_name }}"
+  changed_when: true
+  when:
+    - frr_version_lock | bool
+    - not frr_versionlock.stdout is search('(?m)^' ~ frr_package_name ~ '-[0-9]+:')
+
+- name: Unlock frr package
+  become: true
+  ansible.builtin.command: "dnf versionlock delete {{ frr_package_name }}"
+  changed_when: true
+  when:
+    - not frr_version_lock | bool
+    - frr_versionlock.stdout is search('(?m)^' ~ frr_package_name ~ '-[0-9]+:')


### PR DESCRIPTION
The Debian family only pinned frr via `/etc/apt/preferences.d/frr` with a glob on `frr_version`. That does not lock the version in use: if the glob matches nothing in the repository the pin has no effect at all, and within the glob apt keeps upgrading (8.1.0 → 8.1.5). An `apt-get upgrade` could therefore pull in a new frr and restart the daemon.

- New `frr_version_lock` variable (`true` by default) puts the installed package on hold, analogous to how the `docker` role handles containerd: `apt-mark hold` via `dpkg_selections` on the Debian family, `dnf versionlock` on the RedHat family.
- The package is always unlocked before it is installed, independent of the flag, because `apt-get` aborts with `E: Held packages were changed` as soon as the role has to change the version. Setting `frr_version_lock` to `false` releases an existing lock again on the next run.
- On the RedHat family the versionlock was already set unconditionally, so the default keeps the previous behaviour there. It now runs *after* the installation, so the version actually in use is locked instead of the one available in the repository at that time, and `add`/`delete` are guarded by `dnf versionlock list` instead of being hidden behind `changed_when: false`.
- `test_version_lock` in the molecule tests asserts the hold via `apt-mark showhold` resp. `dnf versionlock list`.

Note for the release notes: on the Debian family this changes behaviour — with the default of `true`, frr is put on hold on existing deployments on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)