### PR TITLE
dnsdist: make backends and ACLs configurable, restart on config change

### DIFF
--- a/roles/dnsdist/defaults/main.yml
+++ b/roles/dnsdist/defaults/main.yml
@@ -48,3 +48,7 @@ dnsdist_servers:
 #dnsdist_servers:
 #  - address: '"208.67.222.222"'
 #    qps: 10
+
+dnsdist_acls:
+  - 0.0.0.0/0
+  - ::/0

--- a/roles/dnsdist/defaults/main.yml
+++ b/roles/dnsdist/defaults/main.yml
@@ -41,3 +41,10 @@ dnsdist_servers:
   - 208.67.220.220
   - 208.67.222.220
   - 208.67.220.222
+# alternatively use mappings to pass entries to newServer(), see
+# https://www.dnsdist.org/reference/config.html#lua-newServer for a full list
+# of options.
+# Make sure to add quotes to strings
+#dnsdist_servers:
+#  - address: '"208.67.222.222"'
+#    qps: 10

--- a/roles/dnsdist/tasks/config.yml
+++ b/roles/dnsdist/tasks/config.yml
@@ -20,3 +20,4 @@
     group: "{{ operator_group }}"
   loop:
     - dnsdist.conf
+  notify: Restart dnsdist service

--- a/roles/dnsdist/templates/dnsdist.conf.j2
+++ b/roles/dnsdist/templates/dnsdist.conf.j2
@@ -5,7 +5,9 @@ addLocal('{{ host | ansible.utils.ipwrap }}:{{ dnsdist_port }}')
 {% else %}
 addLocal('0.0.0.0:53')
 {% endif %}
-setACL({'0.0.0.0/0', '::/0'})
+{% if dnsdist_acls %}
+setACL({{ '{' }}'{{ dnsdist_acls | join("', '") }}'{{ '}' }})
+{% endif %}
 
 {% for server in dnsdist_servers %}
 {% if server is mapping %}

--- a/roles/dnsdist/templates/dnsdist.conf.j2
+++ b/roles/dnsdist/templates/dnsdist.conf.j2
@@ -8,7 +8,11 @@ addLocal('0.0.0.0:53')
 setACL({'0.0.0.0/0', '::/0'})
 
 {% for server in dnsdist_servers %}
+{% if server is mapping %}
+newServer({{ '{' }}{{ server | items | map('join', '=') | join(', ') }}{{ '}' }})
+{% else %}
 newServer({address="{{ server }}", qps=5})
+{% endif %}
 {% endfor %}
 
 setServerPolicy(firstAvailable)


### PR DESCRIPTION
The dnsdist role hardcoded the backend parameters and the ACL in `dnsdist.conf.j2`, and a change to the rendered configuration never reached the running container.

- **Backends with arbitrary parameters:** entries in `dnsdist_servers` may now be mappings, each key/value pair is passed to dnsdist's [`newServer()`](https://www.dnsdist.org/reference/config.html#lua-newServer) as `key=value`. Plain string entries still render as `newServer({address="…", qps=5})`, so existing configurations keep working unchanged. This allows granular control over the backend configuration, e.g. overriding `checkName`/`checkType` in an airgapped environment where the default health check name cannot be resolved. Strings need their own quotes (`address: '"208.67.222.222"'`); a commented example in the defaults shows the form.
- **Configurable ACL:** the hardcoded `setACL({'0.0.0.0/0', '::/0'})` moves into the new `dnsdist_acls` variable, which defaults to exactly these two entries. An empty list omits the `setACL()` call, leaving dnsdist at its built-in default.
- **Restart on configuration change:** `Copy configuration files` in `tasks/config.yml` now notifies `Restart dnsdist service`. So far only a change to the docker-compose file (`tasks/service.yml`) triggered the handler, so a modified `dnsdist.conf` was written to disk while the container kept running with the old configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
