### PR TITLE
httpd: serve a stable onie-installer for ONIE

### DIFF
--- a/molecule/delegated/tests/httpd.py
+++ b/molecule/delegated/tests/httpd.py
@@ -18,6 +18,36 @@ def test_httpd_directories(host):
         assert f.group == get_variable(host, "operator_group")
 
 
+def test_httpd_onie_installer_link(host):
+    link = host.file(
+        "%s/%s/%s"
+        % (
+            get_variable(host, "httpd_data_directory"),
+            get_variable(host, "httpd_sonic_ztp_directory"),
+            get_variable(host, "httpd_sonic_ztp_onie_installer_name"),
+        )
+    )
+
+    assert link.is_symlink
+    assert link.linked_to.endswith(
+        "%s%s%s"
+        % (
+            get_variable(host, "httpd_sonic_ztp_firmware_prefix"),
+            get_variable(host, "httpd_sonic_ztp_onie_installer_version"),
+            get_variable(host, "httpd_sonic_ztp_firmware_suffix"),
+        )
+    )
+
+
+def test_httpd_onie_installer_rewrite(host):
+    directory = get_variable(host, "httpd_configuration_directory")
+    f = host.file("%s/httpd.conf" % directory)
+
+    assert f.contains("mod_rewrite.so")
+    assert f.contains("RewriteEngine On")
+    assert f.contains("ONIE-SERIAL-NUMBER")
+
+
 def test_httpd_service(host):
     service = host.service(get_variable(host, "httpd_service_name"))
 

--- a/molecule/delegated/vars/httpd.yml
+++ b/molecule/delegated/vars/httpd.yml
@@ -6,4 +6,6 @@ httpd_data_enable: true
 httpd_sonic_ztp_enable: true
 httpd_ironic_enable: true
 
+httpd_sonic_ztp_onie_installer_version: "4.5.2"
+
 httpd_sonic_ztp_authorized_keys: ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHAsus5/h/wwuUKr1c9/6UFZe7T0oh6Zsv8gSoQvpMaR test@test.test"]

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -79,6 +79,12 @@ httpd_sonic_ztp_firmware_prefix: sonic-broadcom-enterprise-base_
 httpd_sonic_ztp_firmware_identifier: serial-number
 httpd_sonic_ztp_firmware_suffix: .bin
 
+# Stable name a switch in ONIE asks for, so the ONIE DHCP option (114) can
+# point to a URL that does not change with the firmware version.
+httpd_sonic_ztp_onie_installer_name: onie-installer
+httpd_sonic_ztp_onie_installer_version: ""
+httpd_sonic_ztp_onie_installer_per_device: true
+
 httpd_sonic_ztp_authorized_keys: []
 httpd_sonic_ztp_authorized_keys_delete: []
 

--- a/roles/httpd/tasks/sonic-ztp.yml
+++ b/roles/httpd/tasks/sonic-ztp.yml
@@ -10,6 +10,32 @@
   loop:
     - "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}"
 
+- name: Create onie-installer link
+  ansible.builtin.file:
+    src: "{{ httpd_sonic_ztp_firmware_prefix }}{{ httpd_sonic_ztp_onie_installer_version }}{{ httpd_sonic_ztp_firmware_suffix }}"
+    dest: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_onie_installer_name }}"
+    state: link
+    force: true
+    follow: false
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+  when: httpd_sonic_ztp_onie_installer_version | length > 0
+
+- name: Stat onie-installer link
+  ansible.builtin.stat:
+    path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_onie_installer_name }}"
+    follow: false
+  register: _httpd_sonic_ztp_onie_installer
+  when: httpd_sonic_ztp_onie_installer_version | length == 0
+
+- name: Remove onie-installer link
+  ansible.builtin.file:
+    path: "{{ httpd_data_directory }}/{{ httpd_sonic_ztp_directory }}/{{ httpd_sonic_ztp_onie_installer_name }}"
+    state: absent
+  when:
+    - httpd_sonic_ztp_onie_installer_version | length == 0
+    - _httpd_sonic_ztp_onie_installer.stat.islnk | default(false)
+
 - name: Set ssh authorized keys
   ansible.posix.authorized_key:
     key: "{{ item }}"

--- a/roles/httpd/templates/httpd.conf.j2
+++ b/roles/httpd/templates/httpd.conf.j2
@@ -1,3 +1,4 @@
+{% set _httpd_sonic_ztp_onie_per_device = httpd_sonic_ztp_enable | bool and httpd_sonic_ztp_onie_installer_per_device | bool and httpd_sonic_ztp_firmware_identifier == "serial-number" %}
 ServerRoot "/usr/local/apache2"
 ServerAdmin metal@in-a-box.cloud
 
@@ -52,6 +53,9 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule reqtimeout_module modules/mod_reqtimeout.so
+{% if _httpd_sonic_ztp_onie_per_device %}
+LoadModule rewrite_module modules/mod_rewrite.so
+{% endif %}
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule status_module modules/mod_status.so
 LoadModule unixd_module modules/mod_unixd.so
@@ -88,6 +92,19 @@ LoadModule ssl_module modules/mod_ssl.so
         Options Indexes FollowSymLinks
         AllowOverride All
         Require all granted
+{% if _httpd_sonic_ztp_onie_per_device %}
+
+        # A switch in ONIE sends its serial number with every installer
+        # request. Serve the per device image that is also used for the ZTP
+        # firmware install, so a switch installed from ONIE ends up on the
+        # same version it would get from ZTP. Requests without that header,
+        # and requests for a device that has no image, fall through to
+        # {{ httpd_sonic_ztp_onie_installer_name }} itself.
+        RewriteEngine On
+        RewriteCond %{HTTP:ONIE-SERIAL-NUMBER} ^[A-Za-z0-9][A-Za-z0-9._-]*$
+        RewriteCond /usr/local/apache2/sonic/{{ httpd_sonic_ztp_firmware_prefix }}%{HTTP:ONIE-SERIAL-NUMBER}{{ httpd_sonic_ztp_firmware_suffix }} -f
+        RewriteRule ^{{ httpd_sonic_ztp_onie_installer_name }}$ {{ httpd_sonic_ztp_firmware_prefix }}%{HTTP:ONIE-SERIAL-NUMBER}{{ httpd_sonic_ztp_firmware_suffix }} [L]
+{% endif %}
     </Directory>
 
     ProxyPreserveHost On


### PR DESCRIPTION
### What

Makes the ONIE installer URL independent of the firmware version, and lets that one URL resolve per switch.

### Why

On the ZTP path the firmware is already handled: `ztp.json` builds the install from `<prefix><identifier><suffix>`, and the conductor keeps `<prefix><serial><suffix>` pointing at `<prefix><version><suffix>` from `sonic_parameters.version` in NetBox. A firmware update there is a NetBox change plus `osism sync sonic`.

The ONIE path has no such handle. ONIE takes an exact URL from DHCP option 114, so the image name sits in the DHCP option itself (metalbox `environments/infrastructure/configuration.yml`):

```yaml
dnsmasq_dhcp_options:
  - tag:onie,114,http://metalbox/sonic/sonic-broadcom-enterprise-base_4.4.2.bin
```

Every firmware update therefore means editing the dnsmasq options and re-rendering the dnsmasq configuration, and the version ends up in a second place next to the one the conductor maintains.

### What this adds

* `httpd_sonic_ztp_onie_installer_version` keeps `onie-installer` in the sonic ztp directory as a relative symlink to `<prefix><version><suffix>`, the same image name the ZTP firmware install uses. The DHCP option can then point to `http://metalbox/sonic/onie-installer` and stays untouched across firmware updates.
* `httpd_sonic_ztp_onie_installer_per_device` (default true, rendered only with the `serial-number` identifier, because ONIE has no hostname) resolves that URL per switch. ONIE sends an `ONIE-SERIAL-NUMBER` header with every installer request, so a rewrite serves `<prefix><serial><suffix>` when such an image exists, which is the per device symlink the conductor already creates from NetBox. A switch installed from ONIE then lands on the same version it would get from ZTP.

Nothing changes for existing deployments: `httpd_sonic_ztp_onie_installer_version` is empty by default, so no link is created, and the rewrite only ever touches requests for `onie-installer`, which nothing asks for until the DHCP option is repointed.

### Behaviour worth knowing

* The link is reconciled on every run and may dangle until the image is imported, the same way the conductor creates its per device links.
* Clearing the version removes the link again, but only when it is a symlink, so an image an operator placed at that name by hand is never deleted. With a version set, the link wins over such a file.
* The `-f` test in the rewrite means a missing or dangling per device image falls back to `onie-installer` instead of answering 404.

### Testing

* Rendered `httpd.conf` for ztp off, ztp on with and without the per device flag, and with identifier `hostname`, and checked that the guards hold.
* Ran the three new tasks against a scratch directory: create with a missing target, idempotent re-run, repoint to another version, removal when the version is cleared, and a real file at that path left alone.
* `yamllint`, `ansible-lint` (production profile) and `black` pass.
* molecule delegated: the version is set in `vars/httpd.yml` and `tests/httpd.py` asserts the link target and the rendered rewrite. The httpd container starts with the rendered configuration there, so an invalid Apache configuration or a missing `mod_rewrite.so` in `httpd:alpine` would show up as a failing `test_httpd_container`. I could not run molecule locally.

### Follow up

A companion change in osism/metalbox that points the DHCP option at the stable URL and replaces `httpd_sonic_ztp_firmware` (nothing in this collection reads it any more) with `httpd_sonic_ztp_onie_installer_version`. Happy to open it once this lands.

### One question

The metalbox configuration names the image `sonic-broadcom-enterprise-base-4.4.2.bin` with a dash, while `httpd_sonic_ztp_firmware_prefix` ends with an underscore, so the ZTP firmware link resolves to `sonic-broadcom-enterprise-base_4.4.2.bin`. Is the underscore name the expected name on disk, and is the dash in the metalbox default simply the vendor file name that never got renamed?
