### PR TITLE
manager: reload the services when an environment file changes

### DIFF
--- a/roles/manager/tasks/config-ansible.yml
+++ b/roles/manager/tasks/config-ansible.yml
@@ -16,3 +16,5 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up

--- a/roles/manager/tasks/config-ara.yml
+++ b/roles/manager/tasks/config-ara.yml
@@ -9,6 +9,8 @@
   loop:
     - ara
     - ara-server
+  notify:
+    - Ensure that all containers are up
 
 - name: Copy MariaDB environment file
   ansible.builtin.template:
@@ -18,3 +20,5 @@
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
   when: ara_server_database_type == "mysql"
+  notify:
+    - Ensure that all containers are up

--- a/roles/manager/tasks/config-celery.yml
+++ b/roles/manager/tasks/config-celery.yml
@@ -28,6 +28,8 @@
   loop:
     - conductor
     - openstack
+  notify:
+    - Ensure that all containers are up
 
 - name: Copy listener environment file
   ansible.builtin.template:
@@ -37,6 +39,8 @@
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
   when: enable_listener|bool
+  notify:
+    - Ensure that all containers are up
 
 # NOTE: Since we deploy the manager, we use the conductor.yml directly from the manager.
 

--- a/roles/manager/tasks/config-frontend.yml
+++ b/roles/manager/tasks/config-frontend.yml
@@ -6,3 +6,5 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up

--- a/roles/manager/tasks/config-netbox.yml
+++ b/roles/manager/tasks/config-netbox.yml
@@ -31,6 +31,8 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up
 
 - name: Copy inventory-reconciler environment file
   ansible.builtin.template:
@@ -39,3 +41,5 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up

--- a/roles/manager/tasks/config-vault.yml
+++ b/roles/manager/tasks/config-vault.yml
@@ -6,6 +6,8 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up
 
 - name: Copy Vault configuration file
   ansible.builtin.template:

--- a/roles/manager/tasks/config.yml
+++ b/roles/manager/tasks/config.yml
@@ -24,6 +24,8 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up
 
 - name: Copy client environment file
   ansible.builtin.template:
@@ -32,6 +34,8 @@
     mode: 0640
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
+  notify:
+    - Ensure that all containers are up
 
 - name: Include ara config tasks
   ansible.builtin.include_tasks: config-ara.yml


### PR DESCRIPTION
## The problem

A change to `netbox_role_mapping` never reached the inventory reconciler on a production manager. The new value was in `/opt/manager/configuration/inventory-reconciler.env`, `osism apply manager` reported `changed=0`, and the running container still had the mapping it had been created with, so the generated inventory kept the old host groups.

The symptom is silent. The reconciler runs to completion and writes every file, the groups are simply the old ones:

```
$ grep NETBOX_ROLE_MAPPING /opt/manager/configuration/inventory-reconciler.env
NETBOX_ROLE_MAPPING='@json {"control": ["generic", "control", "monitoring", "ceph-control"], ...}'

$ docker exec $(docker ps -q --filter name=inventory_reconciler) env | grep NETBOX_ROLE_MAPPING
NETBOX_ROLE_MAPPING=@json {"control": ["generic", "control", "monitoring"], ...}
```

## The cause

In `roles/manager`, only the `docker-compose.yml` template in `tasks/service.yml` notifies a handler. The eleven tasks that render an environment file notify nothing, so a change to any manager environment value is written to disk and never delivered to the container that reads it. The environment of a container is fixed when it is created, so a restart cannot pick it up either.

## The change

Those eleven tasks now notify `Ensure that all containers are up`, which already exists in `handlers/main.yml` and runs

```
docker compose --project-directory /opt/manager up -d
```

## Why that handler and not `Restart manager service`

Measured with docker 29.7.2 and compose v5.5.0 on a two service project with an `env_file` each:

| action | container id | value in the container |
| --- | --- | --- |
| created | `f0486ec5c1ce` | `old-mapping` |
| env file changed, then `docker restart` | `f0486ec5c1ce`, same | `old-mapping`, unchanged |
| then `docker compose up -d` | `6cc1beaa0ab9`, new | `new-mapping` |
| `up -d` again, nothing changed | `6cc1beaa0ab9`, same | prints `Running`, no recreate |
| two services, one env file changed | only that one is `Recreated` | the other keeps its id |

The last two rows are the reason. Compose narrows the work to the services whose resolved environment actually differs, so this handler is idempotent when nothing changed and surgical when something did. `compose-go` resolves `env_file` into the service environment at load time and `ServiceHash` covers it, which is why the content of the file, not just its path, decides the recreation.

Notifying `Restart manager service` instead would restart the whole manager stack through systemd and then wait the hardcoded minute of `Wait for manager service to start` for every environment change.

## Tested

* `yamllint -c .yamllint.yml` on the changed files: clean.
* `ansible-lint roles/manager`: passes at the production profile, 65 files.
* every `notify` in `roles/manager/tasks` resolves to a handler in `roles/manager/handlers/main.yml`.
* the compose behaviour above, on real docker and compose.

The role itself was not converged in CI by me: `molecule/delegated` runs with `managed: false` and `ansible_connection: local`, so it converges onto the machine that runs it, which is not something I could do on a workstation.
