### PR TITLE
manager: unbuffer the osism CLI wrapper

### DIFF
--- a/roles/manager/templates/wrapper/osism.j2
+++ b/roles/manager/templates/wrapper/osism.j2
@@ -20,6 +20,19 @@ if [[ $INTERACTIVE == "true" ]]; then
 
 fi
 
+# Python block-buffers stdout when it is not a TTY, so without this a
+# non-interactive invocation -- CI, cron, `> log`, or the very common
+# `osism apply ... | tee log` -- receives the play output one 8 KB block at a
+# time instead of as it happens. A chatty play fills 8 KB in seconds and nobody
+# notices; a long quiet one does not. `osism apply tempest` emits only a ~85
+# byte "STILL ALIVE" banner every 30 s for hours, so a block takes ~49 minutes
+# to fill and the run looks hung for ~50 minutes at a stretch.
+#
+# Note this cannot be solved with stdbuf (as run-openstack.sh attempts):
+# stdbuf hooks libc stdio via LD_PRELOAD, and python does not use libc for
+# sys.stdout.
+PARAMETERS="$PARAMETERS --env PYTHONUNBUFFERED=1"
+
 # The update from the docker service on the manager is done with
 # osism-update-docker script as it cannot be done within a container as it
 # may be recreated during the update.


### PR DESCRIPTION
## What this changes

`roles/manager/templates/wrapper/osism.j2` — the template rendered to `/usr/local/bin/osism` on the manager, i.e. the `osism` command operators and scripts actually invoke. It ends in:

```bash
docker exec -i $PARAMETERS osismclient osism "$@"
```

so everything it runs is a python process inside the `osismclient` container.

## The problem

Python block-buffers stdout when it is not a TTY. The wrapper adds `-t` to `$PARAMETERS` only when stdin, stdout **and** stderr are all TTYs:

```bash
if [[ -t 0 && -t 1 && -t 2 ]]; then
    INTERACTIVE=${INTERACTIVE:-true}
```

So every non-interactive invocation runs that in-container python — and the `ansible-playbook` it spawns, which writes the play output — with a pipe on stdout. That output then arrives one 8 KB block at a time instead of as it happens.

The affected cases are not exotic:

```
osism apply <role> | tee run.log
osism apply <role> > run.log 2>&1
ssh manager 'osism apply <role>'      # no TTY requested
cron / CI / systemd units
```

Only a bare interactive terminal with no redirection escapes it, and piping a long run to `tee` is the natural thing to do.

A chatty play fills 8 KB in seconds, so this is invisible almost everywhere. A long quiet play is the opposite: `osism apply tempest` emits nothing but a ~85-byte `STILL ALIVE` banner every 30 s for hours, so one block takes `98 × 30 s ≈ 49 minutes` to fill.

Measured on an 18.7 h tempest run: the log sat unchanged for ~40 minutes, then grew by **exactly 8200 bytes carrying 98 banners at once**. The run looks hung for ~50 minutes at a stretch while tempest is still completing tests.

## Why not stdbuf

`run-openstack.sh` already wraps itself in `stdbuf -oL`, which cannot work here: `stdbuf` installs a libc stdio hook via `LD_PRELOAD`, and python does not use libc stdio for `sys.stdout`. The `ansible-playbook` process is unaffected.

## The change

Add `PYTHONUNBUFFERED=1` to `$PARAMETERS`. Set unconditionally — it is a no-op in the interactive case, where the allocated TTY already gives line buffering.

## Testing

Neither test involves any caller-side workaround.

**The wrapper emits the flag** — the rendered wrapper contains no Jinja, so it runs as a plain script with a stub `docker` on `PATH`, making the argv directly observable:

| case | resulting `docker` argv |
|---|---|
| non-interactive, before | `exec -i osismclient osism apply tempest` |
| non-interactive, after | `exec -i --env PYTHONUNBUFFERED=1 osismclient osism apply tempest` |
| `INTERACTIVE=true`, after | `exec -i -t --env PYTHONUNBUFFERED=1 osismclient osism apply tempest` |
| `OSISM_APPLY_RETRY=1`, after | `exec -i --env PYTHONUNBUFFERED=1 --env OSISM_APPLY_RETRY=1 osismclient ...` |

`osism update docker` still short-circuits to `osism-update-docker` before reaching `docker exec`. A caller that already sets `PARAMETERS` itself yields a duplicated `--env` with the same value, which is accepted.

**The flag changes streaming** — in the real `osismclient` container on a live manager, five lines printed one per second, arrival time recorded on the manager:

| | line0 | line1 | line2 | line3 | line4 |
|---|---|---|---|---|---|
| without `--env` | 01.16 | 01.16 | 01.16 | 01.16 | 01.17 |
| with `--env PYTHONUNBUFFERED=1` | 01.28 | 02.29 | 03.29 | 04.29 | 05.29 |

And the `stdbuf` claim above, checked the same way — `stdbuf -oL python3 slow.py | …` bursts all six lines at 45.62–45.63, while `PYTHONUNBUFFERED=1` delivers one per second. `stdbuf` really does not reach Python's `sys.stdout`.

Not done: installing the rendered wrapper on a manager and running a full play through it. The two checks above cover each half — the wrapper emits the flag, and the flag changes streaming in the real container — but not their composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
