### PR TITLE
manager: support an HTTP proxy for the manager services

### DIFF
--- a/molecule/delegated/tests/manager.py
+++ b/molecule/delegated/tests/manager.py
@@ -6,6 +6,47 @@ from packaging.version import Version
 
 testinfra_runner, testinfra_hosts = get_ansible()
 
+MANAGER_DEFAULTS = "../../roles/manager/defaults/main.yml"
+MANAGER_FIXTURE = "../../molecule/delegated/vars/manager.yml"
+ALL_ENV_TEMPLATE = "../../roles/manager/templates/env/all.env.j2"
+
+PROXY_VARIABLES = [
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+]
+
+
+def render_all_env(host, **variables):
+    """Render env/all.env.j2 of the manager role with the given variables.
+
+    The role defaults and the molecule fixture are passed to Ansible as extra
+    vars, so the templated defaults, above all manager_proxy_no_proxy, are
+    evaluated by Ansible in the same way as in the role. The given variables
+    take precedence over both. Returns the rendered file as a dictionary.
+    """
+    variables = {
+        **host.ansible("include_vars", MANAGER_DEFAULTS)["ansible_facts"],
+        **host.ansible("include_vars", MANAGER_FIXTURE)["ansible_facts"],
+        **variables,
+    }
+    path = host.ansible("tempfile", "suffix=.env", check=False)["path"]
+    try:
+        host.ansible(
+            "template",
+            f"src={ALL_ENV_TEMPLATE} dest={path}",
+            check=False,
+            extra_vars=variables,
+        )
+        content = host.file(path).content_string
+    finally:
+        host.ansible("file", f"path={path} state=absent", check=False)
+
+    return dict(line.split("=", 1) for line in content.splitlines() if line)
+
 
 # testing config.yml tasks
 def test_manager_config(host):
@@ -45,20 +86,11 @@ def test_manager_config(host):
     assert all_env.group == get_variable(host, "operator_group")
     assert "INVENTORY_RECONCILER_SCHEDULE=" in all_env.content_string
 
-    proxy_variables = [
-        "HTTP_PROXY",
-        "http_proxy",
-        "HTTPS_PROXY",
-        "https_proxy",
-        "NO_PROXY",
-        "no_proxy",
-    ]
-    if get_variable(host, "manager_configure_proxy"):
-        for variable in proxy_variables:
-            assert f"{variable}=" in all_env.content_string
-    else:
-        for variable in proxy_variables:
-            assert f"{variable}=" not in all_env.content_string
+    # NOTE: The molecule fixture keeps the proxy disabled, this is the
+    #       disabled branch of all.env.j2. The enabled branch is covered by
+    #       test_manager_proxy_environment on a rendering of the template.
+    for variable in PROXY_VARIABLES:
+        assert f"{variable}=" not in all_env.content_string
 
     # config-ara
     if host.file(get_variable(host, "enable_ara")) == "true":
@@ -175,6 +207,54 @@ def test_manager_config(host):
         assert "#!/usr/bin/env bash" in f.content_string
 
 
+def test_manager_proxy_environment(host):
+    # NOTE: The enabled branch is rendered separately from the converge.
+    #       Enabling the proxy in the molecule fixture would send the
+    #       outbound traffic of every manager service to an unreachable
+    #       proxy for the rest of the scenario.
+    proxy = "http://proxy.molecule.test:3128"
+    no_proxy_extra = ["192.168.16.0/20", "api-int.molecule.test"]
+    manager_network = get_variable(host, "manager_network")
+    manager_network_ipv6 = get_variable(host, "manager_network_ipv6")
+
+    environment = render_all_env(
+        host,
+        manager_configure_proxy=True,
+        manager_proxy_http=proxy,
+        manager_proxy_no_proxy_extra=no_proxy_extra,
+        manager_network_enable_ipv6=False,
+    )
+    assert environment["HTTP_PROXY"] == proxy
+    assert environment["http_proxy"] == proxy
+    # manager_proxy_https follows manager_proxy_http by default
+    assert environment["HTTPS_PROXY"] == proxy
+    assert environment["https_proxy"] == proxy
+    assert environment["no_proxy"] == environment["NO_PROXY"]
+
+    no_proxy = environment["NO_PROXY"].split(",")
+    assert manager_network in no_proxy
+    assert manager_network_ipv6 not in no_proxy
+    # from manager_proxy_no_proxy_default and from ansible_services
+    for name in [
+        "localhost",
+        "api",
+        "netbox",
+        "openstack",
+        "osism-ansible",
+        "kolla-ansible",
+    ]:
+        assert name in no_proxy, f"Service '{name}' is not excluded from the proxy"
+    for entry in no_proxy_extra:
+        assert entry in no_proxy, f"Entry '{entry}' is not excluded from the proxy"
+
+    environment = render_all_env(
+        host,
+        manager_configure_proxy=True,
+        manager_network_enable_ipv6=True,
+    )
+    assert manager_network_ipv6 in environment["NO_PROXY"].split(",")
+
+
 def test_max_user_watches_and_instances(host):
     sysctl_max_user_watches = host.sysctl("fs.inotify.max_user_watches")
     assert sysctl_max_user_watches == 32768
@@ -260,8 +340,12 @@ def test_docker_compose(host):
     for name in [
         "api",
         "beat",
+        "conductor",
         "flower",
         "inventory_reconciler",
+        "listener",
+        "netbox",
+        "openstack",
         "osism-ansible",
         "osismclient",
         "watchdog",

--- a/molecule/delegated/tests/manager.py
+++ b/molecule/delegated/tests/manager.py
@@ -1,5 +1,6 @@
 import pytest
 import re
+import yaml
 from .util.util import get_ansible, get_variable, get_role_variable
 from packaging.version import Version
 
@@ -35,6 +36,29 @@ def test_manager_config(host):
     assert client_env.user == get_variable(host, "operator_user")
     assert client_env.group == get_variable(host, "operator_group")
     assert "OPENSEARCH_ADDRESS=" in client_env.content_string
+
+    all_env = host.file(f"{config_dir}/all.env")
+    assert all_env.exists
+    assert not all_env.is_directory
+    assert all_env.mode == 0o640
+    assert all_env.user == get_variable(host, "operator_user")
+    assert all_env.group == get_variable(host, "operator_group")
+    assert "INVENTORY_RECONCILER_SCHEDULE=" in all_env.content_string
+
+    proxy_variables = [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ]
+    if get_variable(host, "manager_configure_proxy"):
+        for variable in proxy_variables:
+            assert f"{variable}=" in all_env.content_string
+    else:
+        for variable in proxy_variables:
+            assert f"{variable}=" not in all_env.content_string
 
     # config-ara
     if host.file(get_variable(host, "enable_ara")) == "true":
@@ -228,6 +252,25 @@ def test_docker_compose(host):
             assert re.search(
                 rf'container_name: "{container}"', f.content_string
             ), f"Container name '{container}' not found in docker-compose.yml"
+
+    # NOTE: all.env carries the proxy configuration, every service of the
+    #       manager has to read it, also without the netbox integration.
+    all_env = f"{get_variable(host, 'manager_configuration_directory')}/all.env"
+    services = yaml.safe_load(f.content_string)["services"]
+    for name in [
+        "api",
+        "beat",
+        "flower",
+        "inventory_reconciler",
+        "osism-ansible",
+        "osismclient",
+        "watchdog",
+    ]:
+        if name not in services:
+            continue
+        assert all_env in services[name].get(
+            "env_file", []
+        ), f"Service '{name}' does not read all.env"
 
 
 def test_manager_service(host):

--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -372,6 +372,48 @@ manager_environment_extra: {}
 #   REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
 
 ##########################
+# proxy
+
+# NOTE: The services of the manager use container networking. If the outbound
+#       traffic of the manager network cannot leave the node directly, an HTTP
+#       proxy can be used for the outbound HTTP/HTTPS traffic instead. The
+#       proxy is set for all services of the manager, the traffic within the
+#       manager network is excluded via manager_proxy_no_proxy.
+
+manager_configure_proxy: false
+
+manager_proxy_http: "http://proxy.tld:8080"
+manager_proxy_https: "{{ manager_proxy_http }}"
+
+manager_proxy_no_proxy_default:
+  - localhost
+  - 127.0.0.1
+  - "::1"
+  # NOTE: The services reach each other by their service name within the
+  #       manager network. This traffic never goes through the proxy.
+  - api
+  - ara-server
+  - beat
+  - cache
+  - conductor
+  - flower
+  - frontend
+  - inventory_reconciler
+  - listener
+  - mariadb
+  - netbox
+  - openstack
+  - osismclient
+  - redis
+  - vault
+  - watchdog
+# NOTE: Internal endpoints outside of the manager network belong here, for
+#       example the internal OpenStack API, an internally reachable netbox or
+#       the networks of the managed nodes.
+manager_proxy_no_proxy_extra: []
+manager_proxy_no_proxy: "{{ manager_proxy_no_proxy_default + [manager_network] + ([manager_network_ipv6] if manager_network_enable_ipv6 | bool else []) + (ansible_services | map(attribute='name') | list) + manager_proxy_no_proxy_extra }}"
+
+##########################
 # listener
 
 enable_listener: false

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -42,8 +42,10 @@ services:
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
 {%  endif %}
+{% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
+{% if enable_netbox|bool %}
       - "{{ manager_configuration_directory }}/netbox.env"
       - "{{ manager_configuration_directory }}/inventory-reconciler.env"
 {% endif %}
@@ -263,6 +265,8 @@ services:
       - "{{ configuration_directory }}:/opt/configuration:ro"
     healthcheck:
       test: pgrep osism
+    env_file:
+      - "{{ manager_configuration_directory }}/all.env"
 {% endif %}
 
   ##########################################
@@ -285,8 +289,10 @@ services:
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
 {%  endif %}
+{% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
+{% if enable_netbox|bool %}
       - "{{ manager_configuration_directory }}/netbox.env"
       - "{{ manager_configuration_directory }}/openstack.env"
 {% endif %}
@@ -307,8 +313,10 @@ services:
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
 {%  endif %}
+{% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
+{% if enable_netbox|bool %}
       - "{{ manager_configuration_directory }}/netbox.env"
 {% endif %}
 {% endif %}
@@ -363,6 +371,8 @@ services:
     restart: unless-stopped
     image: "{{ osism_image }}"
     command: osism service flower
+    env_file:
+      - "{{ manager_configuration_directory }}/all.env"
 {% if not flower_traefik|bool %}
     ports:
       - "{{ flower_host | ansible.utils.ipwrap }}:{{ flower_port }}:5555"

--- a/roles/manager/templates/docker-compose.yml.j2
+++ b/roles/manager/templates/docker-compose.yml.j2
@@ -41,7 +41,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
@@ -103,7 +103,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     depends_on:
       redis:
@@ -153,7 +153,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
     healthcheck:
       test: pgrep osism
     env_file:
@@ -186,7 +186,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
     healthcheck:
       test: pgrep osism
     env_file:
@@ -211,7 +211,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     healthcheck:
       test: pgrep osism
@@ -241,7 +241,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     healthcheck:
       test: pgrep osism
@@ -288,7 +288,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
@@ -312,7 +312,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
@@ -336,7 +336,7 @@ services:
       - NETBOX_TOKEN
 {%   if netbox_secondaries | length > 0 %}
       - NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
     env_file:
       - "{{ manager_configuration_directory }}/all.env"
@@ -564,7 +564,7 @@ secrets:
 {%   if netbox_secondaries | length > 0 %}
   NETBOX_SECONDARIES:
     file: {{ manager_secrets_directory }}/NETBOX_SECONDARIES
-{%  endif %}
+{%   endif %}
 {% endif %}
 
 ##########################################

--- a/roles/manager/templates/env/all.env.j2
+++ b/roles/manager/templates/env/all.env.j2
@@ -1,2 +1,14 @@
 INVENTORY_RECONCILER_SCHEDULE={{ manager_inventory_reconciler_schedule }}
 GATHER_FACTS_SCHEDULE={{ manager_gather_facts_schedule }}
+{% if manager_configure_proxy | bool %}
+{# NOTE: Both spellings are set on purpose. requests, urllib and the Go
+         based tools accept either of them, aria2c, which is used by the
+         openstack-image-manager to prefetch images, only reads the
+         lowercase names. #}
+HTTP_PROXY={{ manager_proxy_http }}
+http_proxy={{ manager_proxy_http }}
+HTTPS_PROXY={{ manager_proxy_https }}
+https_proxy={{ manager_proxy_https }}
+NO_PROXY={{ manager_proxy_no_proxy | join(',') }}
+no_proxy={{ manager_proxy_no_proxy | join(',') }}
+{% endif %}


### PR DESCRIPTION
Closes the manager side of osism/issues#1432.

The manager services use container networking. Where the outbound traffic of the manager network cannot leave the node directly, an HTTP proxy is the way out — but there was no way to configure one, and the workaround from the issue cannot work:

* `all.env` is rendered from `env/all.env.j2`, so a hand-written `HTTP_PROXY` in `/opt/manager/configuration/all.env` is overwritten by the next `osism apply manager`.
* `manager_environment_extra`, the only extension point today, ends up in `ansible.env` and therefore reaches `osism-ansible`, the other ansible services and `osismclient` — but not the `openstack` worker, which is the service that runs `openstack-image-manager`.

## What this changes

* New variables in the `manager` role, named after the pattern of the `docker` role: `manager_configure_proxy` (default `false`), `manager_proxy_http`, `manager_proxy_https`, `manager_proxy_no_proxy_default` / `_extra` / `manager_proxy_no_proxy`.
* `all.env` renders `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` in upper **and** lower case. Both spellings are deliberate: `requests` and `urllib` read either of them, `aria2c` — which `openstack-image-manager` uses to prefetch images — reads only the lowercase names.
* `NO_PROXY` is assembled from the service names of the manager, the manager network (plus the IPv6 network when enabled), the names from `ansible_services`, and `manager_proxy_no_proxy_extra` for internal endpoints outside of the manager network. Without it every internal call — netbox, api, vault, the internal OpenStack API — would be sent to the proxy.
* `all.env` is now read by every service that runs an OSISM image. The `env_file` block of `inventory_reconciler`, `api` and `beat` sat inside `{% if enable_netbox %}`, `watchdog` and `flower` had none at all, so without the netbox integration those services received neither the schedules nor the proxy. `netbox.env`, `inventory-reconciler.env` and `openstack.env` stay conditional, they are only rendered with netbox respectively celery enabled. The services that do not run an OSISM image (`redis`, `mariadb`, `ara-server`, `vault`, `frontend`) deliberately keep their own environment.

## Configuration

```yaml
manager_configure_proxy: true
manager_proxy_http: "http://10.0.0.10:3128"
manager_proxy_no_proxy_extra:
  - 192.168.16.0/20
  - api-int.example.com
```

## Testing

The templates were rendered with `ansible-playbook` for netbox on/off, celery on/off, proxy on/off and with an IPv6 manager network. The result parses as YAML in every combination and `all.env` is in the `env_file` list of every OSISM service. `yamllint` with the repository configuration and `flake8` are clean.

The molecule test for the manager role covers `all.env` from the converge as the disabled branch, the fixture keeps `manager_configure_proxy` off. The enabled branch is covered by `test_manager_proxy_environment`, which renders `env/all.env.j2` through Ansible with the role defaults and the molecule fixture as extra vars and asserts on the rendered values: the proxy URL in both spellings, `HTTPS_PROXY` following `manager_proxy_http`, and `NO_PROXY` carrying the manager network, the IPv6 network only when it is enabled, service names from `manager_proxy_no_proxy_default` and from `ansible_services`, and the entries of `manager_proxy_no_proxy_extra`. `test_docker_compose` asserts over the rendered compose file that every service running an OSISM image reads `all.env`, including `openstack`, `conductor`, `netbox` and `listener`.

## Not covered here

* `openstack-image-manager` is started with an empty environment by `python-osism`, so the proxy stops at that boundary until osism/python-osism#2682 is fixed.
* Images imported with `web-download` are downloaded by Glance itself, not by the manager. Those need the proxy on the kolla side, or the prefetch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
