### PR TITLE
Support wazuh_agent enrollment

### DIFF
--- a/roles/wazuh_agent/defaults/main.yml
+++ b/roles/wazuh_agent/defaults/main.yml
@@ -34,3 +34,14 @@ wazuh_agent_client_id: 0001
 wazuh_agent_client_name: sample
 wazuh_agent_client_address: any
 wazuh_agent_client_password: password
+
+##########################
+# enrollment
+
+wazuh_agent_enrollment_enabled: false
+wazuh_agent_enrollment_key: ""
+wazuh_agent_enrollment_manager_address: ""
+wazuh_agent_enrollment_agent_name: ""
+wazuh_agent_enrollment_port: ""
+wazuh_agent_enrollment_groups: ""
+wazuh_agent_enrollment_agent_address: ""

--- a/roles/wazuh_agent/tasks/main.yml
+++ b/roles/wazuh_agent/tasks/main.yml
@@ -12,6 +12,18 @@
     mode: 0660
   notify: Restart wazuh-agent service
 
+- name: Copy authd.pass file
+  become: true
+  ansible.builtin.copy:
+    content: "{{ wazuh_agent_enrollment_key }}"
+    dest: /var/ossec/etc/authd.pass
+    owner: root
+    group: wazuh
+    mode: 0640
+  when: wazuh_agent_enrollment_key | length > 0
+  no_log: true
+  notify: Restart wazuh-agent service
+
 - name: Copy client.keys file
   become: true
   ansible.builtin.template:
@@ -20,6 +32,7 @@
     owner: root
     group: wazuh
     mode: 0640
+  when: not wazuh_agent_enrollment_enabled | bool
   notify: Restart wazuh-agent service
 
 - name: Manage wazuh-agent service

--- a/roles/wazuh_agent/templates/ossec.conf.j2
+++ b/roles/wazuh_agent/templates/ossec.conf.j2
@@ -16,6 +16,26 @@
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
     <crypto_method>aes</crypto_method>
+    {% if wazuh_agent_enrollment_enabled | bool %}
+    <enrollment>
+      <enabled>yes</enabled>
+      {% if wazuh_agent_enrollment_manager_address | length > 0 %}
+      <manager_address>{{ wazuh_agent_enrollment_manager_address }}</manager_address>
+      {% endif %}
+      {% if wazuh_agent_enrollment_agent_name | length > 0 %}
+      <agent_name>{{ wazuh_agent_enrollment_agent_name }}</agent_name>
+      {% endif %}
+      {% if wazuh_agent_enrollment_port | string | length > 0 %}
+      <port>{{ wazuh_agent_enrollment_port }}</port>
+      {% endif %}
+      {% if wazuh_agent_enrollment_groups | length > 0 %}
+      <groups>{{ wazuh_agent_enrollment_groups }}</groups>
+      {% endif %}
+      {% if wazuh_agent_enrollment_agent_address | length > 0 %}
+      <agent_address>{{ wazuh_agent_enrollment_agent_address }}</agent_address>
+      {% endif %}
+    </enrollment>
+    {% endif %}
   </client>
 
   <client_buffer>


### PR DESCRIPTION
Summary

- Add wazuh_agent_enrollment_enabled and related options (manager_address, agent_name, port, groups, agent_address) to render an <enrollment> block in ossec.conf, so agents can auto-register with the Wazuh manager instead of using a static client.keys.
- Add wazuh_agent_enrollment_key, written to /var/ossec/etc/authd.pass (mode 0640, no_log) when set, for authenticated enrollment.
- Skip templating client.keys when enrollment is enabled, since the agent populates it itself after enrolling.

Closes https://github.com/osism/issues/issues/1444

Assisted-by: Claude:claude-sonnet-5