### PR TITLE
manager: drop two orphaned registry defaults

### DIFF
--- a/roles/manager/defaults/main.yml
+++ b/roles/manager/defaults/main.yml
@@ -11,8 +11,6 @@ docker_registry_inventory_reconciler: "{{ docker_registry_ansible }}"
 docker_registry_mariadb: "{{ docker_registry_service }}"
 docker_registry_osism: "{{ docker_registry_ansible }}"
 docker_registry_osism_frontend: "{{ docker_registry_ansible }}"
-docker_registry_osism_netbox: "{{ docker_registry_ansible }}"
-docker_registry_receptor: "{{ docker_registry_ansible }}"
 docker_registry_redis: "{{ docker_registry_service }}"
 docker_registry_vault: "{{ docker_registry_service }}"
 


### PR DESCRIPTION
Deletes two `docker_registry_<alias>` variables from the manager role
defaults that nothing references:

```yaml
docker_registry_osism_netbox: "{{ docker_registry_ansible }}"
docker_registry_receptor: "{{ docker_registry_ansible }}"
```

Neither name occurs anywhere under `roles/`, in the manager playbooks, or in
the generics manager environment, so removing them cannot change a rendered
value. The commit message has the history of how each one was orphaned.

`docker_registry_osism_netbox` is **not** about NetBox, despite the name —
NetBox itself is still shipped by `roles/netbox` via its own
`docker_registry_netbox`. The deleted variable pointed at
`osism/osism-netbox`, a NetBox-specific build of the OSISM CLI image that
stopped being built when netbox-manager was folded into python-osism.

## Where this came from

Both lines are reported by the `role_registry_orphan` drift check, which
walks the chain backward from a role default to ask whether anything
upstream still defines the alias:

- osism/release#2685

It has reported them in every periodic-daily `release-tox-drift` run since
2026-09-10. Most recent as of this PR —
[build 89b29737](https://zuul.services.osism.tech/t/osism/build/89b297371833465d8be23c72be1dcfdf),
2026-09-13:

```
role_registry_orphan — 2 docker_registry_<alias> role defaults that nothing
references (orphaned registry overrides):

    docker_registry_osism_netbox, docker_registry_receptor

  Refs: ansible-collection-services/roles/, ansible-playbooks-manager/playbooks/, generics/environments/manager/
        ansible-collection-services/roles/manager/defaults/main.yml
```

Note that `release-tox-drift` is red on other findings too, and was before
this check landed — these two are 2 of the 8 `to act on` in that run, not
the reason the job is failing.

## Verification

Ran the check against local checkouts with the branch applied:

```
PYTHONPATH=src python3 src/check-drift.py --group image \
  --plugin role_registry_orphan --base-dir ~/data/rcs/osism --remote-fallback
```

| | result |
|---|---|
| `main` | 2 findings, exit 1 |
| this branch | `Summary: 0 to act on`, exit 0 |

## Upgrade impact

None in practice. An operator who set either variable was already setting one
with no effect, so no deprecation cycle is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
